### PR TITLE
Add email_id to SendMagicByEmailResponse

### DIFF
--- a/stytch/magiclink.go
+++ b/stytch/magiclink.go
@@ -22,7 +22,8 @@ func (c *Client) SendMagicLink(body *SendMagicLink) (*SendMagicLinkResponse, err
 	return &retVal, err
 }
 
-func (c *Client) SendMagicLinkByEmail(body *SendMagicLinkByEmail) (*SendMagicLinkResponse, error) {
+func (c *Client) SendMagicLinkByEmail(body *SendMagicLinkByEmail) (*SendMagicLinkByEmailResponse,
+	error) {
 	path := "/magic_links/send_by_email"
 
 	var jsonBody []byte
@@ -35,7 +36,7 @@ func (c *Client) SendMagicLinkByEmail(body *SendMagicLinkByEmail) (*SendMagicLin
 		}
 	}
 
-	var retVal SendMagicLinkResponse
+	var retVal SendMagicLinkByEmailResponse
 	err = c.newRequest("POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }

--- a/stytch/models.go
+++ b/stytch/models.go
@@ -126,6 +126,13 @@ type SendMagicLinkByEmail struct {
 	Attributes        Attributes `json:"attributes,omitempty"`
 }
 
+type SendMagicLinkByEmailResponse struct {
+	RequestID  string `json:"request_id,omitempty"`
+	StatusCode int    `json:"status_code,omitempty"`
+	UserID     string `json:"user_id,omitempty"`
+	EmailID    string `json:"email_id,omitempty"`
+}
+
 type AuthenticateMagicLink struct {
 	Options    Options    `json:"options,omitempty"`
 	Attributes Attributes `json:"attributes,omitempty"`


### PR DESCRIPTION
Updating `/v1/magic_links/send_by_email` to include `email_id` field in response.