### PR TITLE
Bump go.mod Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Go client library for the [Stytch API](https://stytch.com/).
 ## Install
 
 ```console
-$ go get github.com/stytchauth/stytch-go
+$ go get github.com/stytchauth/stytch-go/v3
 ```
 
 ## Documentation

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/stytchauth/stytch-go
+module github.com/stytchauth/stytch-go/v3
 
 go 1.15

--- a/stytch/magiclink/email/email.go
+++ b/stytch/magiclink/email/email.go
@@ -3,8 +3,8 @@ package email
 import (
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/stytch"
-	"github.com/stytchauth/stytch-go/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v3/stytch"
+	"github.com/stytchauth/stytch-go/v3/stytch/stytcherror"
 )
 
 type Client struct {

--- a/stytch/magiclink/magiclink.go
+++ b/stytch/magiclink/magiclink.go
@@ -3,9 +3,9 @@ package magiclink
 import (
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/stytch"
-	"github.com/stytchauth/stytch-go/stytch/magiclink/email"
-	"github.com/stytchauth/stytch-go/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v3/stytch"
+	"github.com/stytchauth/stytch-go/v3/stytch/magiclink/email"
+	"github.com/stytchauth/stytch-go/v3/stytch/stytcherror"
 )
 
 type Client struct {

--- a/stytch/otp/otp.go
+++ b/stytch/otp/otp.go
@@ -3,9 +3,9 @@ package otp
 import (
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/stytch"
-	"github.com/stytchauth/stytch-go/stytch/otp/sms"
-	"github.com/stytchauth/stytch-go/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v3/stytch"
+	"github.com/stytchauth/stytch-go/v3/stytch/otp/sms"
+	"github.com/stytchauth/stytch-go/v3/stytch/stytcherror"
 )
 
 type Client struct {

--- a/stytch/otp/sms/sms.go
+++ b/stytch/otp/sms/sms.go
@@ -3,8 +3,8 @@ package sms
 import (
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/stytch"
-	"github.com/stytchauth/stytch-go/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v3/stytch"
+	"github.com/stytchauth/stytch-go/v3/stytch/stytcherror"
 )
 
 type Client struct {

--- a/stytch/stytch.go
+++ b/stytch/stytch.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/stytchauth/stytch-go/stytch/config"
-	"github.com/stytchauth/stytch-go/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v3/stytch/config"
+	"github.com/stytchauth/stytch-go/v3/stytch/stytcherror"
 )
 
 const (

--- a/stytch/stytchapi/stytchapi.go
+++ b/stytch/stytchapi/stytchapi.go
@@ -1,13 +1,13 @@
 package stytchapi
 
 import (
-	"github.com/stytchauth/stytch-go/stytch"
-	"github.com/stytchauth/stytch-go/stytch/config"
-	"github.com/stytchauth/stytch-go/stytch/magiclink"
-	"github.com/stytchauth/stytch-go/stytch/magiclink/email"
-	"github.com/stytchauth/stytch-go/stytch/otp"
-	"github.com/stytchauth/stytch-go/stytch/otp/sms"
-	"github.com/stytchauth/stytch-go/stytch/user"
+	"github.com/stytchauth/stytch-go/v3/stytch"
+	"github.com/stytchauth/stytch-go/v3/stytch/config"
+	"github.com/stytchauth/stytch-go/v3/stytch/magiclink"
+	"github.com/stytchauth/stytch-go/v3/stytch/magiclink/email"
+	"github.com/stytchauth/stytch-go/v3/stytch/otp"
+	"github.com/stytchauth/stytch-go/v3/stytch/otp/sms"
+	"github.com/stytchauth/stytch-go/v3/stytch/user"
 )
 
 type API struct {

--- a/stytch/stytcherror/stytcherror.go
+++ b/stytch/stytcherror/stytcherror.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/stytchauth/stytch-go/stytch/config"
+	"github.com/stytchauth/stytch-go/v3/stytch/config"
 )
 
 type Error struct {

--- a/stytch/user/user.go
+++ b/stytch/user/user.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/stytchauth/stytch-go/stytch"
-	"github.com/stytchauth/stytch-go/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v3/stytch"
+	"github.com/stytchauth/stytch-go/v3/stytch/stytcherror"
 )
 
 type Client struct {


### PR DESCRIPTION
```
go get github.com/stytchauth/stytch-go@v3.0.0: github.com/stytchauth/stytch-go@v3.0.0: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v3
```

https://stackoverflow.com/questions/53344471/taking-a-repository-to-v2

Created a protected branch for the previous major branch, v2. 