### PR TITLE
feat: Add LastAuthenticatedAt field to AuthenticationFactor

### DIFF
--- a/stytch/attributes.go
+++ b/stytch/attributes.go
@@ -39,8 +39,10 @@ type GoogleOAuthFactor struct {
 }
 
 type AuthenticationFactor struct {
-	Type              string            `json:"type,omitempty"`
-	DeliveryMethod    string            `json:"delivery_method,omitempty"`
+	Type                string `json:"type,omitempty"`
+	DeliveryMethod      string `json:"delivery_method,omitempty"`
+	LastAuthenticatedAt string `json:"last_authenticated_at,omitempty"`
+
 	EmailFactor       EmailFactor       `json:"email_factor,omitempty"`
 	PhoneNumberFactor PhoneNumberFactor `json:"phone_number_factor,omitempty"`
 	GoogleOAuthFactor GoogleOAuthFactor `json:"google_oauth_factor,omitempty"`

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "3.6.0"
+const APIVersion = "3.6.1"
 
 type BaseURI string
 


### PR DESCRIPTION
Exposes the newly-added `last_authenticated_at` timestamp on sessions authentication factors.

I tested this by sending myself a magic link and verifying that `client.MagicLinks.Authenticate` (with `SessionDurationMinutes` set) returns the right timestamp on `res.Session.AuthenticationFactors[0]`.
