### PR TITLE
Fix Name

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "3.7.0"
+const APIVersion = "3.7.1"
 
 type BaseURI string
 

--- a/stytch/user.go
+++ b/stytch/user.go
@@ -1,9 +1,9 @@
 package stytch
 
 type Name struct {
-	FirstName  string `json:"firstName,omitempty"`
-	MiddleName string `json:"middleName,omitempty"`
-	LastName   string `json:"lastName,omitempty"`
+	FirstName  string `json:"first_name,omitempty"`
+	MiddleName string `json:"middle_name,omitempty"`
+	LastName   string `json:"last_name,omitempty"`
 }
 
 type Email struct {


### PR DESCRIPTION
The json definition of the name struct was incorrect so we haven't ever been including name in responses where a name is present. This PR updates the struct definition to be correct.