### PR TITLE
fix: Send JWKS project ID as a path param

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "4.0.0"
+const APIVersion = "4.0.1"
 
 type BaseURI string
 

--- a/stytch/session/session.go
+++ b/stytch/session/session.go
@@ -30,13 +30,10 @@ func (c *Client) Get(
 
 func (c *Client) GetJWKS(
 	body *stytch.SessionsGetJWKSParams) (*stytch.SessionsGetJWKSResponse, error) {
-	queryParams := make(map[string]string)
-	if body != nil {
-		queryParams["project_id"] = body.ProjectID
-	}
+	path := "/sessions/jwks/" + body.ProjectID
 
 	var retVal stytch.SessionsGetJWKSResponse
-	err := c.C.NewRequest("GET", "/sessions/jwks", queryParams, nil, &retVal)
+	err := c.C.NewRequest("GET", path, nil, nil, &retVal)
 	return &retVal, err
 }
 


### PR DESCRIPTION
The route for the JWKS takes the project ID as a path param instead of a query param. This fixes
the request builder for the route.

I tested by running this:
```
resp, err := client.Sessions.GetJWKS(&stytch.SessionsGetJWKSParams{ProjectID: projectID})
log.Println(err)
log.Println(resp)
```
