### PR TITLE
fix: update JWT validation to use UTC time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - uses: actions/setup-go@v2.1.3
+        with:
+          go-version: 1.16
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2.3.0
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           version: v1.30
           args: --timeout 5m

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "4.0.1"
+const APIVersion = "4.0.2"
 
 type BaseURI string
 

--- a/stytch/session/session.go
+++ b/stytch/session/session.go
@@ -54,7 +54,7 @@ func (c *Client) AuthenticateJWT(
 	if claims.IsValid(c.C.Config.BasicAuthProjectID()) != nil {
 		// If JWT is invalid, return error
 		return nil, fmt.Errorf("JWT is invalid or session claims do not match parameters")
-	} else if claims.RegisteredClaims.IssuedAt.Add(maxTokenAge).After(time.Now()) {
+	} else if claims.RegisteredClaims.IssuedAt.Add(maxTokenAge).After(time.Now().UTC()) {
 		// If JWT is valid and the token is less than maxTokenAge old,
 		// assume that it's valid and return the session
 		session := marshalJWTIntoSession(claims)


### PR DESCRIPTION
To maintain consistency, JWT validation should use UTC time across the board