### PR TITLE
feat: Add client.Session.AuthenticateJWTLocal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.15
 require (
 	github.com/MicahParks/keyfunc v1.0.1
 	github.com/golang-jwt/jwt/v4 v4.4.0
+	github.com/stretchr/testify v1.7.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,16 @@
 github.com/MicahParks/keyfunc v1.0.1 h1:BIKfiyELXV0A8SRCHQaByJW0s71xXpArhzfTS3uf26c=
 github.com/MicahParks/keyfunc v1.0.1/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.4.0 h1:EmVIxB5jzbllGIjiCV5JG4VylbK3KE400tLGLI1cdfU=
 github.com/golang-jwt/jwt/v4 v4.4.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.0.0"
+const APIVersion = "5.1.0"
 
 type BaseURI string
 

--- a/stytch/session/session_test.go
+++ b/stytch/session/session_test.go
@@ -1,0 +1,150 @@
+package session_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/MicahParks/keyfunc"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stytchauth/stytch-go/v5/stytch"
+	"github.com/stytchauth/stytch-go/v5/stytch/config"
+	"github.com/stytchauth/stytch-go/v5/stytch/session"
+)
+
+func TestAuthenticateJWTLocal(t *testing.T) {
+	client := &stytch.Client{
+		Config: &config.Config{
+			Env:       config.EnvTest,
+			BaseURI:   "https://example.test/v1/",
+			ProjectID: "project-test-00000000-0000-0000-0000-000000000000",
+			Secret:    "secret-test-11111111-1111-1111-1111-111111111111",
+		},
+		// In these tests, the keyset has already been downloaded, so no other network requests
+		// should be made.
+		HTTPClient: nil,
+	}
+
+	key := rsaKey(t)
+	keyID := "jwk-test-22222222-2222-2222-2222-222222222222"
+	jwks := keyfunc.NewGiven(map[string]keyfunc.GivenKey{
+		keyID: keyfunc.NewGivenRSA(&key.PublicKey),
+	})
+
+	sessions := &session.Client{
+		C:    client,
+		JWKS: jwks,
+	}
+
+	t.Run("expired JWT", func(t *testing.T) {
+		iat := time.Now().Add(-time.Hour).Truncate(time.Second)
+		exp := iat.Add(time.Minute)
+
+		claims := sandboxClaims(t, iat, exp)
+		token := signJWT(t, keyID, key, claims)
+
+		s, err := sessions.AuthenticateJWTLocal(token, 5*time.Minute)
+		assert.ErrorIs(t, err, jwt.ErrTokenExpired)
+		assert.Nil(t, s)
+	})
+
+	t.Run("stale JWT", func(t *testing.T) {
+		iat := time.Now().Add(-10 * time.Minute).Truncate(time.Second)
+		exp := iat.Add(time.Hour)
+
+		claims := sandboxClaims(t, iat, exp)
+		token := signJWT(t, keyID, key, claims)
+
+		s, err := sessions.AuthenticateJWTLocal(token, 5*time.Minute)
+		assert.ErrorIs(t, err, session.ErrJWTTooOld)
+		assert.Nil(t, s)
+	})
+
+	t.Run("valid JWT", func(t *testing.T) {
+		iat := time.Now().Truncate(time.Second)
+		exp := iat.Add(time.Hour)
+
+		claims := sandboxClaims(t, iat, exp)
+		token := signJWT(t, keyID, key, claims)
+
+		session, err := sessions.AuthenticateJWTLocal(token, 5*time.Minute)
+		require.NoError(t, err)
+
+		expected := &stytch.Session{
+			SessionID:      "session-live-e26a0ccb-0dc0-4edb-a4bb-e70210f43555",
+			UserID:         "user-live-fde03dd1-fff7-4b3c-9b31-ead3fbc224de",
+			StartedAt:      iat.Format(time.RFC3339),
+			LastAccessedAt: iat.Format(time.RFC3339),
+			ExpiresAt:      exp.String(),
+			Attributes: stytch.Attributes{
+				IPAddress: "",
+				UserAgent: "",
+			},
+			AuthenticationFactors: []*stytch.AuthenticationFactor{
+				{
+					Type:                "magic_link",
+					DeliveryMethod:      "email",
+					LastAuthenticatedAt: iat.Format(time.RFC3339),
+					EmailFactor: stytch.EmailFactor{
+						EmailAddress: "sandbox@stytch.com",
+						EmailID:      "email-live-cca9d7d0-11b6-4167-9385-d7e0c9a77418",
+					},
+				},
+			},
+		}
+		assert.Equal(t, expected, session)
+	})
+}
+
+func rsaKey(t *testing.T) *rsa.PrivateKey {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("generate test RSA key: %s", err)
+	}
+	return key
+}
+
+func signJWT(t *testing.T, keyID string, key *rsa.PrivateKey, claims jwt.Claims) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = keyID
+
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign JWT: %s", err)
+	}
+	return signed
+}
+
+func sandboxClaims(t *testing.T, iat, exp time.Time) stytch.Claims {
+	return stytch.Claims{
+		StytchSession: stytch.SessionClaim{
+			ID:             "session-live-e26a0ccb-0dc0-4edb-a4bb-e70210f43555",
+			StartedAt:      iat.Format(time.RFC3339),
+			LastAccessedAt: iat.Format(time.RFC3339),
+			Attributes:     stytch.Attributes{},
+			AuthenticationFactors: []stytch.AuthenticationFactor{
+				{
+					Type:                "magic_link",
+					DeliveryMethod:      "email",
+					LastAuthenticatedAt: iat.Format(time.RFC3339),
+					EmailFactor: stytch.EmailFactor{
+						EmailAddress: "sandbox@stytch.com",
+						EmailID:      "email-live-cca9d7d0-11b6-4167-9385-d7e0c9a77418",
+					},
+				},
+			},
+		},
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        "session-live-e26a0ccb-0dc0-4edb-a4bb-e70210f43555",
+			Issuer:    "stytch.com/project-test-00000000-0000-0000-0000-000000000000",
+			Audience:  []string{"project-test-00000000-0000-0000-0000-000000000000"},
+			Subject:   "user-live-fde03dd1-fff7-4b3c-9b31-ead3fbc224de",
+			IssuedAt:  jwt.NewNumericDate(iat),
+			NotBefore: jwt.NewNumericDate(iat),
+			ExpiresAt: jwt.NewNumericDate(exp),
+		},
+	}
+}

--- a/stytch/session/session_test.go
+++ b/stytch/session/session_test.go
@@ -100,6 +100,9 @@ func TestAuthenticateJWTLocal(t *testing.T) {
 }
 
 func rsaKey(t *testing.T) *rsa.PrivateKey {
+	// This short key length is fine for test data. We won't actually use the keys for anything.
+	//
+	// #nosec G403
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		t.Fatalf("generate test RSA key: %s", err)


### PR DESCRIPTION
Some apps may find it useful to authenticate a JWT entirely locally without automatically falling
back to the `/sessions/authenticate` endpoint. This adds an `AuthenticateJWTLocal` to support
that.

This also introduces a new `ErrJWTTooOld` value for errors from the `maxTokenAge` option.