### PR TITLE
fix: Extract the session ID from the session claim

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.1.0"
+const APIVersion = "5.1.1"
 
 type BaseURI string
 

--- a/stytch/session/session.go
+++ b/stytch/session/session.go
@@ -95,7 +95,7 @@ func marshalJWTIntoSession(claims stytch.Claims) stytch.Session {
 		authFactorPtrs = append(authFactorPtrs, &factor)
 	}
 	return stytch.Session{
-		SessionID:             claims.RegisteredClaims.ID,
+		SessionID:             claims.StytchSession.ID,
 		UserID:                claims.RegisteredClaims.Subject,
 		StartedAt:             claims.StytchSession.StartedAt,
 		LastAccessedAt:        claims.StytchSession.LastAccessedAt,

--- a/stytch/session/session_test.go
+++ b/stytch/session/session_test.go
@@ -141,7 +141,6 @@ func sandboxClaims(t *testing.T, iat, exp time.Time) stytch.Claims {
 			},
 		},
 		RegisteredClaims: jwt.RegisteredClaims{
-			ID:        "session-live-e26a0ccb-0dc0-4edb-a4bb-e70210f43555",
 			Issuer:    "stytch.com/project-test-00000000-0000-0000-0000-000000000000",
 			Audience:  []string{"project-test-00000000-0000-0000-0000-000000000000"},
 			Subject:   "user-live-fde03dd1-fff7-4b3c-9b31-ead3fbc224de",


### PR DESCRIPTION
In session JWTs, the session claim is the more reliable source of the session ID. The "jti" claim
happens to also contain that now, but it will not in the future.
