### PR TITLE
Add SessionToken and SessionJwt to OAuthAuthenticate response

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.2.0"
+const APIVersion = "5.3.0"
 
 type BaseURI string
 

--- a/stytch/oauth.go
+++ b/stytch/oauth.go
@@ -27,6 +27,8 @@ type OAuthAuthenticateResponse struct {
 	ProviderSubject string         `json:"provider_subject,omitempty"`
 	ProviderType    ProviderType   `json:"provider_type,omitempty"`
 	Session         *Session       `json:"session,omitempty"`
+	SessionToken    string         `json:"session_token,omitempty"`
+	SessionJWT      string         `json:"session_jwt,omitempty"`
 	ProviderValues  ProviderValues `json:"provider_values,omitempty"`
 }
 


### PR DESCRIPTION
Closes https://github.com/stytchauth/stytch-go/issues/64 by adding the SessionToken and SessionJwt fields.