### PR TITLE
fix: Prefer session.expires_at value in session JWT claims

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.3.1"
+const APIVersion = "5.3.2"
 
 type BaseURI string
 

--- a/stytch/session.go
+++ b/stytch/session.go
@@ -61,6 +61,7 @@ type SessionClaim struct {
 	ID                    string                 `json:"id"`
 	StartedAt             string                 `json:"started_at"`
 	LastAccessedAt        string                 `json:"last_accessed_at"`
+	ExpiresAt             string                 `json:"expires_at"`
 	Attributes            Attributes             `json:"attributes"`
 	AuthenticationFactors []AuthenticationFactor `json:"authentication_factors"`
 }

--- a/stytch/session/session.go
+++ b/stytch/session/session.go
@@ -90,12 +90,19 @@ func marshalJWTIntoSession(claims stytch.Claims) stytch.Session {
 		factor := factor
 		authFactorPtrs = append(authFactorPtrs, &factor)
 	}
+
+	// For JWTs that include it, prefer the inner expires_at claim.
+	expiresAt := claims.StytchSession.ExpiresAt
+	if expiresAt == "" {
+		expiresAt = claims.RegisteredClaims.ExpiresAt.Time.Format(time.RFC3339)
+	}
+
 	return stytch.Session{
 		SessionID:             claims.StytchSession.ID,
 		UserID:                claims.RegisteredClaims.Subject,
 		StartedAt:             claims.StytchSession.StartedAt,
 		LastAccessedAt:        claims.StytchSession.LastAccessedAt,
-		ExpiresAt:             claims.RegisteredClaims.ExpiresAt.String(),
+		ExpiresAt:             expiresAt,
 		Attributes:            claims.StytchSession.Attributes,
 		AuthenticationFactors: authFactorPtrs,
 	}


### PR DESCRIPTION
Stytch session JWTs now include the session's `expires_at` value within the session data claim. If
present, prefer using that value to determine the session's expiration. For backward compatibility
with old tokens that don't include it, continue using the value from the "exp" claim.

This also includes a fix for the "exp" claim's value so it's formatted like the other timestamps.
