### PR TITLE
feat: Add WithBaseURI option to run on internal dev API

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.3.2"
+const APIVersion = "5.4.0"
 
 type BaseURI string
 

--- a/stytch/stytchapi/stytchapi.go
+++ b/stytch/stytchapi/stytchapi.go
@@ -48,8 +48,8 @@ func WithLogger(logger Logger) Option {
 // WithBaseURI overrides the client base URI determined by the environment.
 //
 // The value derived from stytch.EnvLive or stytch.EnvTest is already correct for production use
-// in the live or test environment, respectively. This is implemented to make it easier to use
-// this client to access development versions of the API.
+// in the Live or Test environment, respectively. This is implemented to make it easier to use
+// this client to access internal development versions of the API.
 func WithBaseURI(uri string) Option {
 	return func(api *API) { api.client.Config.BaseURI = config.BaseURI(uri) }
 }

--- a/stytch/stytchapi/stytchapi.go
+++ b/stytch/stytchapi/stytchapi.go
@@ -45,6 +45,15 @@ func WithLogger(logger Logger) Option {
 	return func(api *API) { api.logger = logger }
 }
 
+// WithBaseURI overrides the client base URI determined by the environment.
+//
+// The value derived from stytch.EnvLive or stytch.EnvTest is already correct for production use
+// in the live or test environment, respectively. This is implemented to make it easier to use
+// this client to access development versions of the API.
+func WithBaseURI(uri string) Option {
+	return func(api *API) { api.client.Config.BaseURI = config.BaseURI(uri) }
+}
+
 func NewAPIClient(env config.Env, projectID string, secret string, opts ...Option) (*API, error) {
 	a := &API{
 		client: stytch.New(env, projectID, secret),

--- a/stytch/stytchapi/stytchapi_test.go
+++ b/stytch/stytchapi/stytchapi_test.go
@@ -1,0 +1,66 @@
+package stytchapi_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stytchauth/stytch-go/v5/stytch"
+	"github.com/stytchauth/stytch-go/v5/stytch/config"
+	"github.com/stytchauth/stytch-go/v5/stytch/stytchapi"
+)
+
+func TestNewClient(t *testing.T) {
+	t.Run("live environment", func(t *testing.T) {
+		_, err := stytchapi.NewAPIClient(
+			stytch.EnvLive,
+			"project-live-00000000-0000-0000-0000-000000000000",
+			"secret-live-11111111-1111-1111-1111-111111111111",
+		)
+		assert.NoError(t, err)
+	})
+
+	t.Run("test environment", func(t *testing.T) {
+		_, err := stytchapi.NewAPIClient(
+			stytch.EnvTest,
+			"project-test-00000000-0000-0000-0000-000000000000",
+			"secret-test-11111111-1111-1111-1111-111111111111",
+		)
+		assert.NoError(t, err)
+	})
+
+	t.Run("internal development override", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Handle the async JWKS fetch
+			if strings.HasPrefix(r.URL.Path, "/sessions/jwks/") {
+				w.Write([]byte(`{"keys": []}`))
+				return
+			}
+
+			// This is the test request
+			if r.URL.Path == "/magic_links/authenticate" {
+				w.Write([]byte(`{}`))
+				return
+			}
+
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}))
+		_ = srv
+
+		client, err := stytchapi.NewAPIClient(
+			config.Env("anything"),
+			"project-test-00000000-0000-0000-0000-000000000000",
+			"secret-test-11111111-1111-1111-1111-111111111111",
+			stytchapi.WithBaseURI(srv.URL),
+		)
+		assert.NoError(t, err)
+
+		_, err = client.MagicLinks.Authenticate(&stytch.MagicLinksAuthenticateParams{
+			Token: "fake-token",
+		})
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
API client setup uses the `env` value to set the correct base URI for that environment. This is
great for the production live and test environments (which are the only supported ones!), but that
makes it difficult to use this within a Stytch development environment as a Stytch API developer.

So this adds a new `WithBaseURI` option to override the derived default.
