### PR TITLE
feat: Add user object to update and authenticate responses

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.4.2"
+const APIVersion = "5.5.0"
 
 type BaseURI string
 

--- a/stytch/cryptowallet.go
+++ b/stytch/cryptowallet.go
@@ -30,4 +30,5 @@ type CryptoWalletAuthenticateResponse struct {
 	SessionToken string  `json:"session_token,omitempty"`
 	SessionJWT   string  `json:"session_jwt,omitempty"`
 	Session      Session `json:"session,omitempty"`
+	User         User    `jspon:"user,omitempty"`
 }

--- a/stytch/magiclink.go
+++ b/stytch/magiclink.go
@@ -30,6 +30,7 @@ type MagicLinksAuthenticateResponse struct {
 	SessionToken string  `json:"session_token,omitempty"`
 	SessionJWT   string  `json:"session_jwt,omitempty"`
 	Session      Session `json:"session,omitempty"`
+	User         User    `jspon:"user,omitempty"`
 }
 
 // MAGIC LINK - EMAIL

--- a/stytch/otp.go
+++ b/stytch/otp.go
@@ -18,6 +18,7 @@ type OTPsAuthenticateResponse struct {
 	SessionToken string  `json:"session_token,omitempty"`
 	Session      Session `json:"session,omitempty"`
 	SessionJWT   string  `json:"session_jwt,omitempty"`
+	User         User    `jspon:"user,omitempty"`
 }
 
 // OTP - SMS

--- a/stytch/session.go
+++ b/stytch/session.go
@@ -47,6 +47,7 @@ type SessionsAuthenticateResponse struct {
 	Session      Session `json:"session,omitempty"`
 	SessionToken string  `json:"session_token,omitempty"`
 	SessionJWT   string  `json:"session_jwt,omitempty"`
+	User         User    `jspon:"user,omitempty"`
 }
 
 type SessionsRevokeParams struct {

--- a/stytch/totp.go
+++ b/stytch/totp.go
@@ -36,6 +36,7 @@ type TOTPsAuthenticateResponse struct {
 	SessionToken string  `json:"session_token,omitempty"`
 	SessionJWT   string  `json:"session_jwt,omitempty"`
 	Session      Session `json:"session,omitempty"`
+	User         User    `jspon:"user,omitempty"`
 }
 
 type TOTPsRecoveryCodesParams struct {
@@ -65,4 +66,5 @@ type TOTPsRecoverResponse struct {
 	SessionToken string  `json:"session_token,omitempty"`
 	SessionJWT   string  `json:"session_jwt,omitempty"`
 	Session      Session `json:"session,omitempty"`
+	User         User    `jspon:"user,omitempty"`
 }

--- a/stytch/user.go
+++ b/stytch/user.go
@@ -78,6 +78,7 @@ type UsersCreateResponse struct {
 	EmailID    string `json:"email_id,omitempty"`
 	PhoneID    string `json:"phone_id,omitempty"`
 	Status     string `json:"status,omitempty"`
+	User       User   `jspon:"user,omitempty"`
 }
 
 type UsersGetResponse struct {
@@ -110,6 +111,7 @@ type UsersUpdateResponse struct {
 	Emails        []Email        `json:"emails,omitempty"`
 	PhoneNumbers  []PhoneNumber  `json:"phone_numbers,omitempty"`
 	CryptoWallets []CryptoWallet `json:"crypto_wallets,omitempty"`
+	User          User           `jspon:"user,omitempty"`
 }
 
 type UsersDeleteResponse struct {
@@ -122,30 +124,35 @@ type UsersDeleteEmailResponse struct {
 	RequestID  string `json:"request_id,omitempty"`
 	StatusCode int    `json:"status_code,omitempty"`
 	UserID     string `json:"user_id,omitempty"`
+	User       User   `jspon:"user,omitempty"`
 }
 
 type UsersDeletePhoneNumberResponse struct {
 	RequestID  string `json:"request_id,omitempty"`
 	StatusCode int    `json:"status_code,omitempty"`
 	UserID     string `json:"user_id,omitempty"`
+	User       User   `jspon:"user,omitempty"`
 }
 
 type UsersDeleteWebAuthnRegistrationResponse struct {
 	RequestID  string `json:"request_id,omitempty"`
 	StatusCode int    `json:"status_code,omitempty"`
 	UserID     string `json:"user_id,omitempty"`
+	User       User   `jspon:"user,omitempty"`
 }
 
 type UsersDeleteTOTPResponse struct {
 	RequestID  string `json:"request_id,omitempty"`
 	StatusCode int    `json:"status_code,omitempty"`
 	UserID     string `json:"user_id,omitempty"`
+	User       User   `jspon:"user,omitempty"`
 }
 
 type UsersDeleteCryptoWalletResponse struct {
 	RequestID  string `json:"request_id,omitempty"`
 	StatusCode int    `json:"status_code,omitempty"`
 	UserID     string `json:"user_id,omitempty"`
+	User       User   `jspon:"user,omitempty"`
 }
 
 /* User Search */

--- a/stytch/webauthn.go
+++ b/stytch/webauthn.go
@@ -53,4 +53,5 @@ type WebAuthnAuthenticateResponse struct {
 	SessionToken           string  `json:"session_token,omitempty"`
 	SessionJWT             string  `json:"session_jwt,omitempty"`
 	Session                Session `json:"session,omitempty"`
+	User                   User    `jspon:"user,omitempty"`
 }


### PR DESCRIPTION
We now return a user object from the following calls:
- Create User
- Update User
- Authenticate Magic Link
- Authenticate OTP
- Authenticate OAuth
- Authenticate TOTP
- Authenticate WebAuthn
- Authenticate Crypto Wallet
- Delete Email / Phone # / TOTP / WebAuth / Crypto Wallet