### PR TITLE
feat: Add types for PKCE in OAuth and EML flows

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.5.0"
+const APIVersion = "5.6.0"
 
 type BaseURI string
 

--- a/stytch/magiclink.go
+++ b/stytch/magiclink.go
@@ -20,6 +20,7 @@ type MagicLinksAuthenticateParams struct {
 	SessionToken           string     `json:"session_token,omitempty"`
 	SessionJWT             string     `json:"session_jwt,omitempty"`
 	SessionDurationMinutes int32      `json:"session_duration_minutes,omitempty"`
+	CodeVerifier           string     `json:"code_verifier,omitempty"`
 }
 
 type MagicLinksAuthenticateResponse struct {
@@ -41,6 +42,7 @@ type MagicLinksEmailSendParams struct {
 	LoginExpirationMinutes  int32      `json:"login_expiration_minutes,omitempty"`
 	SignupExpirationMinutes int32      `json:"signup_expiration_minutes,omitempty"`
 	Attributes              Attributes `json:"attributes,omitempty"`
+	CodeChallenge           string     `json:"code_challenge,omitempty"`
 }
 
 type MagicLinksEmailSendResponse struct {
@@ -58,6 +60,7 @@ type MagicLinksEmailLoginOrCreateParams struct {
 	SignupExpirationMinutes int32      `json:"signup_expiration_minutes,omitempty"`
 	CreateUserAsPending     bool       `json:"create_user_as_pending,omitempty"`
 	Attributes              Attributes `json:"attributes,omitempty"`
+	CodeChallenge           string     `json:"code_challenge,omitempty"`
 }
 
 type MagicLinksEmailLoginOrCreateResponse struct {

--- a/stytch/oauth.go
+++ b/stytch/oauth.go
@@ -18,6 +18,7 @@ type OAuthAuthenticateParams struct {
 	SessionToken           string `json:"session_token,omitempty"`
 	SessionJWT             string `json:"session_jwt,omitempty"`
 	SessionDurationMinutes int32  `json:"session_duration_minutes,omitempty"`
+	CodeVerifier           string `json:"code_verifier"`
 }
 
 type OAuthAuthenticateResponse struct {


### PR DESCRIPTION
Adds `code_challenge` to magic link start methods, and `code_verifier` to magic link and OAuth authenticate methods.

@stytchauth/client-libraries - any suggestion as to whether this should be a patch or a minor?