### PR TITLE
Add Error Logging to Go Client 

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.6.2"
+const APIVersion = "5.6.1"
 
 type BaseURI string
 

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.6.1"
+const APIVersion = "5.6.2"
 
 type BaseURI string
 

--- a/stytch/stytch.go
+++ b/stytch/stytch.go
@@ -16,20 +16,9 @@ const (
 	EnvLive = config.EnvLive
 )
 
-type Logger interface {
-	Printf(format string, v ...interface{})
-}
-
 type Client struct {
 	Config     *config.Config
 	HTTPClient *http.Client
-	logger     Logger
-}
-
-type Option func(*Client)
-
-func WithLogger(logger Logger) Option {
-	return func(client *Client) { client.logger = logger }
 }
 
 func New(env config.Env, projectID string, secret string) *Client {
@@ -82,9 +71,6 @@ func (c *Client) NewRequest(method string, path string, queryParams map[string]s
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		if c.logger != nil {
-			c.logger.Printf("There was an error with sending the http request\nError: %s", err.Error())
-		}
 		return stytcherror.NewClientLibraryError("Oops, something seems to have gone " +
 			"wrong sending the http request")
 	}

--- a/stytch/stytch.go
+++ b/stytch/stytch.go
@@ -47,7 +47,7 @@ func (c *Client) NewRequest(method string, path string, queryParams map[string]s
 
 	req, err := http.NewRequest(method, path, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("error creating a new http request: %w", err)
+		return fmt.Errorf("error creating http request: %w", err)
 	}
 
 	// add query params
@@ -71,7 +71,7 @@ func (c *Client) NewRequest(method string, path string, queryParams map[string]s
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("error sending a new http request: %w", err)
+		return fmt.Errorf("error sending http request: %w", err)
 	}
 	defer func() {
 		res.Body.Close()
@@ -80,7 +80,7 @@ func (c *Client) NewRequest(method string, path string, queryParams map[string]s
 	// Successful response
 	if res.StatusCode == 200 || res.StatusCode == 201 {
 		if err = json.NewDecoder(res.Body).Decode(v); err != nil {
-			return fmt.Errorf("error decoding a new http request: %w", err)
+			return fmt.Errorf("error decoding http request: %w", err)
 		}
 		return nil
 	}
@@ -88,7 +88,7 @@ func (c *Client) NewRequest(method string, path string, queryParams map[string]s
 	// Attempt to unmarshal into Stytch error format
 	var stytchErr stytcherror.Error
 	if err = json.NewDecoder(res.Body).Decode(&stytchErr); err != nil {
-		return fmt.Errorf("error decoding a new http request: %w", err)
+		return fmt.Errorf("error decoding http request: %w", err)
 	}
 	stytchErr.StatusCode = res.StatusCode
 	return stytchErr

--- a/stytch/stytch.go
+++ b/stytch/stytch.go
@@ -81,7 +81,6 @@ func (c *Client) NewRequest(method string, path string, queryParams map[string]s
 	if res.StatusCode == 200 || res.StatusCode == 201 {
 		if err = json.NewDecoder(res.Body).Decode(v); err != nil {
 			return fmt.Errorf("error decoding a new http request: %w", err)
-
 		}
 		return nil
 	}
@@ -90,7 +89,6 @@ func (c *Client) NewRequest(method string, path string, queryParams map[string]s
 	var stytchErr stytcherror.Error
 	if err = json.NewDecoder(res.Body).Decode(&stytchErr); err != nil {
 		return fmt.Errorf("error decoding a new http request: %w", err)
-
 	}
 	stytchErr.StatusCode = res.StatusCode
 	return stytchErr

--- a/stytch/stytch.go
+++ b/stytch/stytch.go
@@ -16,9 +16,20 @@ const (
 	EnvLive = config.EnvLive
 )
 
+type Logger interface {
+	Printf(format string, v ...interface{})
+}
+
 type Client struct {
 	Config     *config.Config
 	HTTPClient *http.Client
+	logger     Logger
+}
+
+type Option func(*Client)
+
+func WithLogger(logger Logger) Option {
+	return func(client *Client) { client.logger = logger }
 }
 
 func New(env config.Env, projectID string, secret string) *Client {
@@ -71,6 +82,9 @@ func (c *Client) NewRequest(method string, path string, queryParams map[string]s
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
+		if c.logger != nil {
+			c.logger.Printf("There was an error with sending the http request\nError: %s", err.Error())
+		}
 		return stytcherror.NewClientLibraryError("Oops, something seems to have gone " +
 			"wrong sending the http request")
 	}


### PR DESCRIPTION
We ran into an issue in the wild, where we hit the error on what was line 74, but were missing the original error message to know how to debug further. 
- adds a logging interface.
- add logging when they reach the error. 