### PR TITLE
Add custom claims support to Go CL

### DIFF
--- a/stytch/attributes.go
+++ b/stytch/attributes.go
@@ -141,8 +141,12 @@ type Session struct {
 	CustomClaims          interface{}             `json:"custom_claims"`
 }
 
+// SessionWrapper wraps a session object with a custom_claims field
+// so that we can unmarshal custom claims from authenticate responses
+type SessionWrapper struct {
+	Session ClaimsWrapper `json:"session"`
+}
+
 type ClaimsWrapper struct {
-	Session struct {
-		Claims interface{} `json:"custom_claims"`
-	} `json:"session"`
+	Claims interface{} `json:"custom_claims"`
 }

--- a/stytch/attributes.go
+++ b/stytch/attributes.go
@@ -138,4 +138,11 @@ type Session struct {
 	ExpiresAt             string                  `json:"expires_at,omitempty"`
 	Attributes            Attributes              `json:"attributes,omitempty"`
 	AuthenticationFactors []*AuthenticationFactor `json:"authentication_factors,omitempty"`
+	CustomClaims          interface{}             `json:"custom_claims"`
+}
+
+type ClaimsWrapper struct {
+	Session struct {
+		Claims interface{} `json:"custom_claims"`
+	} `json:"session"`
 }

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -5,7 +5,7 @@ const APIVersion = "5.6.2"
 type BaseURI string
 
 const (
-	BaseURITest BaseURI = "https://test.stytch.com/v1"
+	BaseURITest BaseURI = "https://test.nikhil.dev.stytch.com/v1"
 	BaseURILive BaseURI = "https://api.stytch.com/v1"
 )
 

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,11 +1,11 @@
 package config
 
-const APIVersion = "5.6.2"
+const APIVersion = "5.7.0"
 
 type BaseURI string
 
 const (
-	BaseURITest BaseURI = "https://test.nikhil.dev.stytch.com/v1"
+	BaseURITest BaseURI = "https://test.stytch.com/v1"
 	BaseURILive BaseURI = "https://api.stytch.com/v1"
 )
 

--- a/stytch/cryptowallet/cryptowallet.go
+++ b/stytch/cryptowallet/cryptowallet.go
@@ -79,10 +79,8 @@ func (c *Client) AuthenticateWithClaims(
 
 	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
 	// the unmarshal fills it.
-	wrapper := stytch.ClaimsWrapper{
-		Session: struct {
-			Claims interface{} `json:"custom_claims"`
-		}{
+	wrapper := stytch.SessionWrapper{
+		Session: stytch.ClaimsWrapper{
 			Claims: claims,
 		},
 	}

--- a/stytch/cryptowallet/cryptowallet.go
+++ b/stytch/cryptowallet/cryptowallet.go
@@ -2,6 +2,7 @@ package cryptowallet
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/stytchauth/stytch-go/v5/stytch"
 	"github.com/stytchauth/stytch-go/v5/stytch/stytcherror"
@@ -46,5 +47,48 @@ func (c *Client) Authenticate(body *stytch.CryptoWalletAuthenticateParams,
 
 	var retVal stytch.CryptoWalletAuthenticateResponse
 	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	return &retVal, err
+}
+
+func (c *Client) AuthenticateWithClaims(
+	body *stytch.CryptoWalletAuthenticateParams,
+	claims interface{},
+) (*stytch.CryptoWalletAuthenticateResponse, error) {
+	path := "/crypto_wallets/authenticate"
+
+	var jsonBody []byte
+	var err error
+	if body != nil {
+		jsonBody, err = json.Marshal(body)
+		if err != nil {
+			return nil, stytcherror.NewClientLibraryError("Oops, something seems to have gone wrong " +
+				"marshalling the authenticate request body")
+		}
+	}
+
+	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// First extract the Stytch data.
+	var retVal stytch.CryptoWalletAuthenticateResponse
+	if err := json.Unmarshal(b, &retVal); err != nil {
+		return nil, fmt.Errorf("unmarshal CryptoWalletAuthenticateResponse: %w", err)
+	}
+
+	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
+	// the unmarshal fills it.
+	wrapper := stytch.ClaimsWrapper{
+		Session: struct {
+			Claims interface{} `json:"custom_claims"`
+		}{
+			Claims: claims,
+		},
+	}
+	if err := json.Unmarshal(b, &wrapper); err != nil {
+		return nil, fmt.Errorf("unmarshal custom claims: %w", err)
+	}
+	retVal.Session.CustomClaims = wrapper.Session.Claims
 	return &retVal, err
 }

--- a/stytch/magiclink.go
+++ b/stytch/magiclink.go
@@ -14,13 +14,14 @@ type MagicLinksCreateResponse struct {
 }
 
 type MagicLinksAuthenticateParams struct {
-	Token                  string     `json:"token,omitempty"`
-	Options                Options    `json:"options,omitempty"`
-	Attributes             Attributes `json:"attributes,omitempty"`
-	SessionToken           string     `json:"session_token,omitempty"`
-	SessionJWT             string     `json:"session_jwt,omitempty"`
-	SessionDurationMinutes int32      `json:"session_duration_minutes,omitempty"`
-	CodeVerifier           string     `json:"code_verifier,omitempty"`
+	Token                  string      `json:"token,omitempty"`
+	Options                Options     `json:"options,omitempty"`
+	Attributes             Attributes  `json:"attributes,omitempty"`
+	SessionToken           string      `json:"session_token,omitempty"`
+	SessionJWT             string      `json:"session_jwt,omitempty"`
+	SessionDurationMinutes int32       `json:"session_duration_minutes,omitempty"`
+	CodeVerifier           string      `json:"code_verifier,omitempty"`
+	CustomClaims           interface{} `json:"custom_claims,omitempty"`
 }
 
 type MagicLinksAuthenticateResponse struct {

--- a/stytch/magiclink.go
+++ b/stytch/magiclink.go
@@ -14,14 +14,13 @@ type MagicLinksCreateResponse struct {
 }
 
 type MagicLinksAuthenticateParams struct {
-	Token                  string      `json:"token,omitempty"`
-	Options                Options     `json:"options,omitempty"`
-	Attributes             Attributes  `json:"attributes,omitempty"`
-	SessionToken           string      `json:"session_token,omitempty"`
-	SessionJWT             string      `json:"session_jwt,omitempty"`
-	SessionDurationMinutes int32       `json:"session_duration_minutes,omitempty"`
-	CodeVerifier           string      `json:"code_verifier,omitempty"`
-	CustomClaims           interface{} `json:"custom_claims,omitempty"`
+	Token                  string     `json:"token,omitempty"`
+	Options                Options    `json:"options,omitempty"`
+	Attributes             Attributes `json:"attributes,omitempty"`
+	SessionToken           string     `json:"session_token,omitempty"`
+	SessionJWT             string     `json:"session_jwt,omitempty"`
+	SessionDurationMinutes int32      `json:"session_duration_minutes,omitempty"`
+	CodeVerifier           string     `json:"code_verifier,omitempty"`
 }
 
 type MagicLinksAuthenticateResponse struct {

--- a/stytch/magiclink/magiclink.go
+++ b/stytch/magiclink/magiclink.go
@@ -2,6 +2,7 @@ package magiclink
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/stytchauth/stytch-go/v5/stytch"
 	"github.com/stytchauth/stytch-go/v5/stytch/magiclink/email"
@@ -52,5 +53,49 @@ func (c *Client) Authenticate(
 
 	var retVal stytch.MagicLinksAuthenticateResponse
 	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	return &retVal, err
+}
+
+func (c *Client) AuthenticateWithClaims(
+	body *stytch.MagicLinksAuthenticateParams,
+	claims interface{},
+) (*stytch.MagicLinksAuthenticateResponse, error) {
+	path := "/magic_links/authenticate"
+
+	var jsonBody []byte
+	var err error
+	if body != nil {
+		jsonBody, err = json.Marshal(body)
+		if err != nil {
+			return nil, stytcherror.NewClientLibraryError(
+				"Oops, something seems to have gone wrong " +
+					"marshalling the /magic_links/authenticate request body")
+		}
+	}
+
+	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// First extract the Stytch data.
+	var retVal stytch.MagicLinksAuthenticateResponse
+	if err := json.Unmarshal(b, &retVal); err != nil {
+		return nil, fmt.Errorf("unmarshal MagicLinksAuthenticateResponse: %w", err)
+	}
+
+	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
+	// the unmarshal fills it.
+	wrapper := stytch.ClaimsWrapper{
+		Session: struct {
+			Claims interface{} `json:"custom_claims"`
+		}{
+			Claims: claims,
+		},
+	}
+	if err := json.Unmarshal(b, &wrapper); err != nil {
+		return nil, fmt.Errorf("unmarshal custom claims: %w", err)
+	}
+	retVal.Session.CustomClaims = wrapper.Session.Claims
 	return &retVal, err
 }

--- a/stytch/magiclink/magiclink.go
+++ b/stytch/magiclink/magiclink.go
@@ -86,10 +86,8 @@ func (c *Client) AuthenticateWithClaims(
 
 	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
 	// the unmarshal fills it.
-	wrapper := stytch.ClaimsWrapper{
-		Session: struct {
-			Claims interface{} `json:"custom_claims"`
-		}{
+	wrapper := stytch.SessionWrapper{
+		Session: stytch.ClaimsWrapper{
 			Claims: claims,
 		},
 	}

--- a/stytch/oauth/oauth.go
+++ b/stytch/oauth/oauth.go
@@ -65,10 +65,8 @@ func (c *Client) AuthenticateWithClaims(
 
 	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
 	// the unmarshal fills it.
-	wrapper := stytch.ClaimsWrapper{
-		Session: struct {
-			Claims interface{} `json:"custom_claims"`
-		}{
+	wrapper := stytch.SessionWrapper{
+		Session: stytch.ClaimsWrapper{
 			Claims: claims,
 		},
 	}

--- a/stytch/oauth/oauth.go
+++ b/stytch/oauth/oauth.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/stytchauth/stytch-go/v5/stytch"
 	"github.com/stytchauth/stytch-go/v5/stytch/magiclink/email"
@@ -31,5 +32,49 @@ func (c *Client) Authenticate(
 
 	var retVal stytch.OAuthAuthenticateResponse
 	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	return &retVal, err
+}
+
+func (c *Client) AuthenticateWithClaims(
+	body *stytch.OAuthAuthenticateParams,
+	claims interface{},
+) (*stytch.OAuthAuthenticateResponse, error) {
+	path := "/oauth/authenticate"
+
+	var jsonBody []byte
+	var err error
+	if body != nil {
+		jsonBody, err = json.Marshal(body)
+		if err != nil {
+			return nil, stytcherror.NewClientLibraryError(
+				"Oops, something seems to have gone wrong " +
+					"marshalling the /oauth/authenticate request body")
+		}
+	}
+
+	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// First extract the Stytch data.
+	var retVal stytch.OAuthAuthenticateResponse
+	if err := json.Unmarshal(b, &retVal); err != nil {
+		return nil, fmt.Errorf("unmarshal OAuthAuthenticateResponse: %w", err)
+	}
+
+	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
+	// the unmarshal fills it.
+	wrapper := stytch.ClaimsWrapper{
+		Session: struct {
+			Claims interface{} `json:"custom_claims"`
+		}{
+			Claims: claims,
+		},
+	}
+	if err := json.Unmarshal(b, &wrapper); err != nil {
+		return nil, fmt.Errorf("unmarshal custom claims: %w", err)
+	}
+	retVal.Session.CustomClaims = wrapper.Session.Claims
 	return &retVal, err
 }

--- a/stytch/otp/otp.go
+++ b/stytch/otp/otp.go
@@ -67,10 +67,8 @@ func (c *Client) AuthenticateWithClaims(
 
 	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
 	// the unmarshal fills it.
-	wrapper := stytch.ClaimsWrapper{
-		Session: struct {
-			Claims interface{} `json:"custom_claims"`
-		}{
+	wrapper := stytch.SessionWrapper{
+		Session: stytch.ClaimsWrapper{
 			Claims: claims,
 		},
 	}

--- a/stytch/otp/otp.go
+++ b/stytch/otp/otp.go
@@ -2,6 +2,7 @@ package otp
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/stytchauth/stytch-go/v5/stytch"
 	"github.com/stytchauth/stytch-go/v5/stytch/otp/email"
@@ -34,5 +35,48 @@ func (c *Client) Authenticate(
 
 	var retVal stytch.OTPsAuthenticateResponse
 	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	return &retVal, err
+}
+
+func (c *Client) AuthenticateWithClaims(
+	body *stytch.OTPsAuthenticateParams,
+	claims interface{},
+) (*stytch.OTPsAuthenticateResponse, error) {
+	path := "/otps/authenticate"
+
+	var jsonBody []byte
+	var err error
+	if body != nil {
+		jsonBody, err = json.Marshal(body)
+		if err != nil {
+			return nil, stytcherror.NewClientLibraryError("Oops, something seems to have gone wrong " +
+				"marshalling the /otps/authenticate request body")
+		}
+	}
+
+	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// First extract the Stytch data.
+	var retVal stytch.OTPsAuthenticateResponse
+	if err := json.Unmarshal(b, &retVal); err != nil {
+		return nil, fmt.Errorf("unmarshal OTPsAuthenticateResponse: %w", err)
+	}
+
+	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
+	// the unmarshal fills it.
+	wrapper := stytch.ClaimsWrapper{
+		Session: struct {
+			Claims interface{} `json:"custom_claims"`
+		}{
+			Claims: claims,
+		},
+	}
+	if err := json.Unmarshal(b, &wrapper); err != nil {
+		return nil, fmt.Errorf("unmarshal custom claims: %w", err)
+	}
+	retVal.Session.CustomClaims = wrapper.Session.Claims
 	return &retVal, err
 }

--- a/stytch/session/session.go
+++ b/stytch/session/session.go
@@ -177,10 +177,8 @@ func (c *Client) AuthenticateWithClaims(
 
 	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
 	// the unmarshal fills it.
-	wrapper := stytch.ClaimsWrapper{
-		Session: struct {
-			Claims interface{} `json:"custom_claims"`
-		}{
+	wrapper := stytch.SessionWrapper{
+		Session: stytch.ClaimsWrapper{
 			Claims: claims,
 		},
 	}

--- a/stytch/session/session_test.go
+++ b/stytch/session/session_test.go
@@ -189,7 +189,7 @@ func TestAuthenticateWithClaims(t *testing.T) {
 		SessionToken: "fake session token",
 	}
 
-	{
+	t.Run("marshaling claims into a map", func(t *testing.T) {
 		var claims map[string]interface{}
 		_, err := client.Sessions.AuthenticateWithClaims(req, &claims)
 		require.NoError(t, err)
@@ -206,34 +206,35 @@ func TestAuthenticateWithClaims(t *testing.T) {
 			},
 		}
 		assert.Equal(t, expected, claims)
-	}
-
-	type MyAppClaims struct {
-		Number int
-		Array  []interface{}
-		Nested struct {
-			Data string
+	})
+	t.Run("marshaling claims into a struct", func(t *testing.T) {
+		type MyAppClaims struct {
+			Number int
+			Array  []interface{}
+			Nested struct {
+				Data string
+			}
 		}
-	}
 
-	type Claims struct {
-		MyApp MyAppClaims `json:"https://my-app.example.net/custom-claim"`
-	}
-
-	{
-		var claims Claims
-		_, err = client.Sessions.AuthenticateWithClaims(req, &claims)
-		require.NoError(t, err)
-		expected := Claims{
-			MyApp: MyAppClaims{
-				Number: 1,
-				// Remember that numbers without specified types unmarshal as float64.
-				Array:  []interface{}{float64(1), "foo", nil},
-				Nested: struct{ Data string }{Data: "here"},
-			},
+		type Claims struct {
+			MyApp MyAppClaims `json:"https://my-app.example.net/custom-claim"`
 		}
-		assert.Equal(t, expected, claims)
-	}
+
+		{
+			var claims Claims
+			_, err = client.Sessions.AuthenticateWithClaims(req, &claims)
+			require.NoError(t, err)
+			expected := Claims{
+				MyApp: MyAppClaims{
+					Number: 1,
+					// Remember that numbers without specified types unmarshal as float64.
+					Array:  []interface{}{float64(1), "foo", nil},
+					Nested: struct{ Data string }{Data: "here"},
+				},
+			}
+			assert.Equal(t, expected, claims)
+		}
+	})
 }
 
 func rsaKey(t *testing.T) *rsa.PrivateKey {

--- a/stytch/stytchapi/stytchapi_test.go
+++ b/stytch/stytchapi/stytchapi_test.go
@@ -48,7 +48,6 @@ func TestNewClient(t *testing.T) {
 			http.Error(w, "Bad Request", http.StatusBadRequest)
 			return
 		}))
-		_ = srv
 
 		client, err := stytchapi.NewAPIClient(
 			config.Env("anything"),

--- a/stytch/totp/totp.go
+++ b/stytch/totp/totp.go
@@ -84,7 +84,7 @@ func (c *Client) AuthenticateWithClaims(
 
 	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
 	// the unmarshal fills it.
-	wrapper := stytch.ClaimsWrapper{
+	wrapper := stytch.SessionWrapper{
 		Session: struct {
 			Claims interface{} `json:"custom_claims"`
 		}{
@@ -170,10 +170,8 @@ func (c *Client) RecoverWithClaims(
 
 	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
 	// the unmarshal fills it.
-	wrapper := stytch.ClaimsWrapper{
-		Session: struct {
-			Claims interface{} `json:"custom_claims"`
-		}{
+	wrapper := stytch.SessionWrapper{
+		Session: stytch.ClaimsWrapper{
 			Claims: claims,
 		},
 	}

--- a/stytch/totp/totp.go
+++ b/stytch/totp/totp.go
@@ -2,6 +2,7 @@ package totp
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/stytchauth/stytch-go/v5/stytch"
 	"github.com/stytchauth/stytch-go/v5/stytch/stytcherror"
@@ -53,6 +54,50 @@ func (c *Client) Authenticate(body *stytch.TOTPsAuthenticateParams) (
 	return &retVal, err
 }
 
+func (c *Client) AuthenticateWithClaims(
+	body *stytch.TOTPsAuthenticateParams,
+	claims interface{},
+) (*stytch.TOTPsAuthenticateResponse, error) {
+	path := "/totps/authenticate"
+
+	var jsonBody []byte
+	var err error
+	if body != nil {
+		jsonBody, err = json.Marshal(body)
+		if err != nil {
+			return nil, stytcherror.NewClientLibraryError(
+				"Oops, something seems to have gone wrong " +
+					"marshalling the /totps/authenticate request body")
+		}
+	}
+
+	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// First extract the Stytch data.
+	var retVal stytch.TOTPsAuthenticateResponse
+	if err := json.Unmarshal(b, &retVal); err != nil {
+		return nil, fmt.Errorf("unmarshal TOTPsAuthenticateResponse: %w", err)
+	}
+
+	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
+	// the unmarshal fills it.
+	wrapper := stytch.ClaimsWrapper{
+		Session: struct {
+			Claims interface{} `json:"custom_claims"`
+		}{
+			Claims: claims,
+		},
+	}
+	if err := json.Unmarshal(b, &wrapper); err != nil {
+		return nil, fmt.Errorf("unmarshal custom claims: %w", err)
+	}
+	retVal.Session.CustomClaims = wrapper.Session.Claims
+	return &retVal, err
+}
+
 func (c *Client) RecoveryCodes(body *stytch.TOTPsRecoveryCodesParams) (
 	*stytch.TOTPsRecoveryCodesResponse, error,
 ) {
@@ -92,5 +137,49 @@ func (c *Client) Recover(body *stytch.TOTPsRecoverParams) (
 
 	var retVal stytch.TOTPsRecoverResponse
 	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	return &retVal, err
+}
+
+func (c *Client) RecoverWithClaims(
+	body *stytch.TOTPsRecoverParams,
+	claims interface{},
+) (*stytch.TOTPsRecoverResponse, error) {
+	path := "/totps/recover"
+
+	var jsonBody []byte
+	var err error
+	if body != nil {
+		jsonBody, err = json.Marshal(body)
+		if err != nil {
+			return nil, stytcherror.NewClientLibraryError(
+				"Oops, something seems to have gone wrong " +
+					"marshalling the /totps/recover request body")
+		}
+	}
+
+	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// First extract the Stytch data.
+	var retVal stytch.TOTPsRecoverResponse
+	if err := json.Unmarshal(b, &retVal); err != nil {
+		return nil, fmt.Errorf("unmarshal TOTPsRecoverResponse: %w", err)
+	}
+
+	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
+	// the unmarshal fills it.
+	wrapper := stytch.ClaimsWrapper{
+		Session: struct {
+			Claims interface{} `json:"custom_claims"`
+		}{
+			Claims: claims,
+		},
+	}
+	if err := json.Unmarshal(b, &wrapper); err != nil {
+		return nil, fmt.Errorf("unmarshal custom claims: %w", err)
+	}
+	retVal.Session.CustomClaims = wrapper.Session.Claims
 	return &retVal, err
 }

--- a/stytch/webauthn/webauthn.go
+++ b/stytch/webauthn/webauthn.go
@@ -117,10 +117,8 @@ func (c *Client) AuthenticateWithClaims(
 
 	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
 	// the unmarshal fills it.
-	wrapper := stytch.ClaimsWrapper{
-		Session: struct {
-			Claims interface{} `json:"custom_claims"`
-		}{
+	wrapper := stytch.SessionWrapper{
+		Session: stytch.ClaimsWrapper{
 			Claims: claims,
 		},
 	}


### PR DESCRIPTION
Create new `AuthenticateWithClaims` functions for each product in order to authenticate that product with custom claims
Custom claims will not be visible on the session object until the product is officially released