### PR TITLE
Further custom claims support

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.8.0"
+const APIVersion = "5.9.0"
 
 type BaseURI string
 

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.9.0"
+const APIVersion = "5.10.0"
 
 type BaseURI string
 

--- a/stytch/cryptowallet.go
+++ b/stytch/cryptowallet.go
@@ -15,12 +15,13 @@ type CryptoWalletAuthenticateStartResponse struct {
 }
 
 type CryptoWalletAuthenticateParams struct {
-	CryptoWalletAddress    string `json:"crypto_wallet_address,omitempty"`
-	CryptoWalletType       string `json:"crypto_wallet_type,omitempty"`
-	Signature              string `json:"signature,omitempty"`
-	SessionToken           string `json:"session_token,omitempty"`
-	SessionJWT             string `json:"session_jwt,omitempty"`
-	SessionDurationMinutes int32  `json:"session_duration_minutes,omitempty"`
+	CryptoWalletAddress    string                 `json:"crypto_wallet_address,omitempty"`
+	CryptoWalletType       string                 `json:"crypto_wallet_type,omitempty"`
+	Signature              string                 `json:"signature,omitempty"`
+	SessionToken           string                 `json:"session_token,omitempty"`
+	SessionJWT             string                 `json:"session_jwt,omitempty"`
+	SessionDurationMinutes int32                  `json:"session_duration_minutes,omitempty"`
+	SessionCustomClaims    map[string]interface{} `json:"session_custom_claims,omitempty"`
 }
 
 type CryptoWalletAuthenticateResponse struct {

--- a/stytch/cryptowallet/cryptowallet.go
+++ b/stytch/cryptowallet/cryptowallet.go
@@ -52,7 +52,8 @@ func (c *Client) Authenticate(body *stytch.CryptoWalletAuthenticateParams,
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See session_test.go for an example
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.CryptoWalletAuthenticateParams,
 	claims interface{},

--- a/stytch/cryptowallet/cryptowallet.go
+++ b/stytch/cryptowallet/cryptowallet.go
@@ -52,7 +52,7 @@ func (c *Client) Authenticate(body *stytch.CryptoWalletAuthenticateParams,
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.CryptoWalletAuthenticateParams,

--- a/stytch/cryptowallet/cryptowallet.go
+++ b/stytch/cryptowallet/cryptowallet.go
@@ -50,6 +50,9 @@ func (c *Client) Authenticate(body *stytch.CryptoWalletAuthenticateParams,
 	return &retVal, err
 }
 
+// AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
+// Pass in a map with the types of values you're expecting so that this function can marshal
+// the claims from the response. See session_test.go for an example
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.CryptoWalletAuthenticateParams,
 	claims interface{},

--- a/stytch/magiclink.go
+++ b/stytch/magiclink.go
@@ -14,13 +14,14 @@ type MagicLinksCreateResponse struct {
 }
 
 type MagicLinksAuthenticateParams struct {
-	Token                  string     `json:"token,omitempty"`
-	Options                Options    `json:"options,omitempty"`
-	Attributes             Attributes `json:"attributes,omitempty"`
-	SessionToken           string     `json:"session_token,omitempty"`
-	SessionJWT             string     `json:"session_jwt,omitempty"`
-	SessionDurationMinutes int32      `json:"session_duration_minutes,omitempty"`
-	CodeVerifier           string     `json:"code_verifier,omitempty"`
+	Token                  string                 `json:"token,omitempty"`
+	Options                Options                `json:"options,omitempty"`
+	Attributes             Attributes             `json:"attributes,omitempty"`
+	SessionToken           string                 `json:"session_token,omitempty"`
+	SessionJWT             string                 `json:"session_jwt,omitempty"`
+	SessionDurationMinutes int32                  `json:"session_duration_minutes,omitempty"`
+	SessionCustomClaims    map[string]interface{} `json:"session_custom_claims,omitempty"`
+	CodeVerifier           string                 `json:"code_verifier,omitempty"`
 }
 
 type MagicLinksAuthenticateResponse struct {

--- a/stytch/magiclink/magiclink.go
+++ b/stytch/magiclink/magiclink.go
@@ -56,6 +56,9 @@ func (c *Client) Authenticate(
 	return &retVal, err
 }
 
+// AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
+// Pass in a map with the types of values you're expecting so that this function can marshal
+// the claims from the response. See session_test.go for an example
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.MagicLinksAuthenticateParams,
 	claims interface{},

--- a/stytch/magiclink/magiclink.go
+++ b/stytch/magiclink/magiclink.go
@@ -58,7 +58,8 @@ func (c *Client) Authenticate(
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See session_test.go for an example
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.MagicLinksAuthenticateParams,
 	claims interface{},

--- a/stytch/magiclink/magiclink.go
+++ b/stytch/magiclink/magiclink.go
@@ -58,7 +58,7 @@ func (c *Client) Authenticate(
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.MagicLinksAuthenticateParams,

--- a/stytch/oauth.go
+++ b/stytch/oauth.go
@@ -14,11 +14,12 @@ const (
 )
 
 type OAuthAuthenticateParams struct {
-	Token                  string `json:"token,omitempty"`
-	SessionToken           string `json:"session_token,omitempty"`
-	SessionJWT             string `json:"session_jwt,omitempty"`
-	SessionDurationMinutes int32  `json:"session_duration_minutes,omitempty"`
-	CodeVerifier           string `json:"code_verifier,omitempty"`
+	Token                  string                 `json:"token,omitempty"`
+	SessionToken           string                 `json:"session_token,omitempty"`
+	SessionJWT             string                 `json:"session_jwt,omitempty"`
+	SessionDurationMinutes int32                  `json:"session_duration_minutes,omitempty"`
+	SessionCustomClaims    map[string]interface{} `json:"session_custom_claims,omitempty"`
+	CodeVerifier           string                 `json:"code_verifier,omitempty"`
 }
 
 type OAuthAuthenticateResponse struct {

--- a/stytch/oauth/oauth.go
+++ b/stytch/oauth/oauth.go
@@ -37,7 +37,7 @@ func (c *Client) Authenticate(
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.OAuthAuthenticateParams,

--- a/stytch/oauth/oauth.go
+++ b/stytch/oauth/oauth.go
@@ -35,6 +35,9 @@ func (c *Client) Authenticate(
 	return &retVal, err
 }
 
+// AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
+// Pass in a map with the types of values you're expecting so that this function can marshal
+// the claims from the response. See session_test.go for an example
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.OAuthAuthenticateParams,
 	claims interface{},

--- a/stytch/oauth/oauth.go
+++ b/stytch/oauth/oauth.go
@@ -37,7 +37,8 @@ func (c *Client) Authenticate(
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See session_test.go for an example
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.OAuthAuthenticateParams,
 	claims interface{},

--- a/stytch/otp.go
+++ b/stytch/otp.go
@@ -1,13 +1,14 @@
 package stytch
 
 type OTPsAuthenticateParams struct {
-	MethodID               string     `json:"method_id"`
-	Code                   string     `json:"code"`
-	Options                Options    `json:"options,omitempty"`
-	Attributes             Attributes `json:"attributes,omitempty"`
-	SessionToken           string     `json:"session_token,omitempty"`
-	SessionDurationMinutes int32      `json:"session_duration_minutes,omitempty"`
-	SessionJWT             string     `json:"session_jwt,omitempty"`
+	MethodID               string                 `json:"method_id"`
+	Code                   string                 `json:"code"`
+	Options                Options                `json:"options,omitempty"`
+	Attributes             Attributes             `json:"attributes,omitempty"`
+	SessionToken           string                 `json:"session_token,omitempty"`
+	SessionDurationMinutes int32                  `json:"session_duration_minutes,omitempty"`
+	SessionCustomClaims    map[string]interface{} `json:"session_custom_claims,omitempty"`
+	SessionJWT             string                 `json:"session_jwt,omitempty"`
 }
 
 type OTPsAuthenticateResponse struct {

--- a/stytch/otp/otp.go
+++ b/stytch/otp/otp.go
@@ -38,6 +38,9 @@ func (c *Client) Authenticate(
 	return &retVal, err
 }
 
+// AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
+// Pass in a map with the types of values you're expecting so that this function can marshal
+// the claims from the response. See session_test.go for an example
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.OTPsAuthenticateParams,
 	claims interface{},

--- a/stytch/otp/otp.go
+++ b/stytch/otp/otp.go
@@ -40,7 +40,7 @@ func (c *Client) Authenticate(
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.OTPsAuthenticateParams,

--- a/stytch/otp/otp.go
+++ b/stytch/otp/otp.go
@@ -40,7 +40,8 @@ func (c *Client) Authenticate(
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See session_test.go for an example
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.OTPsAuthenticateParams,
 	claims interface{},

--- a/stytch/password.go
+++ b/stytch/password.go
@@ -1,9 +1,10 @@
 package stytch
 
 type PasswordsCreateParams struct {
-	Email                  string `json:"email"`
-	Password               string `json:"password"`
-	SessionDurationMinutes int32  `json:"session_duration_minutes,omitempty"`
+	Email                  string                 `json:"email"`
+	Password               string                 `json:"password"`
+	SessionDurationMinutes int32                  `json:"session_duration_minutes,omitempty"`
+	SessionCustomClaims    map[string]interface{} `json:"session_custom_claims,omitempty"`
 }
 
 type PasswordsCreateResponse struct {
@@ -18,11 +19,12 @@ type PasswordsCreateResponse struct {
 }
 
 type PasswordsAuthenticateParams struct {
-	Email                  string `json:"email"`
-	Password               string `json:"password"`
-	SessionToken           string `json:"session_token,omitempty"`
-	SessionJWT             string `json:"session_jwt,omitempty"`
-	SessionDurationMinutes int32  `json:"session_duration_minutes,omitempty"`
+	Email                  string                 `json:"email"`
+	Password               string                 `json:"password"`
+	SessionToken           string                 `json:"session_token,omitempty"`
+	SessionJWT             string                 `json:"session_jwt,omitempty"`
+	SessionDurationMinutes int32                  `json:"session_duration_minutes,omitempty"`
+	SessionCustomClaims    map[string]interface{} `json:"session_custom_claims,omitempty"`
 }
 
 type PasswordsAuthenticateResponse struct {
@@ -95,14 +97,15 @@ type PasswordEmailResetStartResponse struct {
 }
 
 type PasswordEmailResetParams struct {
-	Token                  string     `json:"token,omitempty"`
-	Password               string     `json:"password,omitempty"`
-	SessionToken           string     `json:"session_token,omitempty"`
-	SessionJWT             string     `json:"session_jwt,omitempty"`
-	SessionDurationMinutes int32      `json:"session_duration_minutes,omitempty"`
-	Options                Options    `json:"options,omitempty"`
-	Attributes             Attributes `json:"attributes,omitempty"`
-	CodeVerifier           string     `json:"code_verifier,omitempty"`
+	Token                  string                 `json:"token,omitempty"`
+	Password               string                 `json:"password,omitempty"`
+	SessionToken           string                 `json:"session_token,omitempty"`
+	SessionJWT             string                 `json:"session_jwt,omitempty"`
+	SessionDurationMinutes int32                  `json:"session_duration_minutes,omitempty"`
+	SessionCustomClaims    map[string]interface{} `json:"session_custom_claims,omitempty"`
+	Options                Options                `json:"options,omitempty"`
+	Attributes             Attributes             `json:"attributes,omitempty"`
+	CodeVerifier           string                 `json:"code_verifier,omitempty"`
 }
 
 type PasswordEmailResetResponse struct {

--- a/stytch/password/email/email.go
+++ b/stytch/password/email/email.go
@@ -56,7 +56,7 @@ func (c *Client) Reset(
 
 // ResetWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) ResetWithClaims(
 	body *stytch.PasswordEmailResetParams,

--- a/stytch/password/email/email.go
+++ b/stytch/password/email/email.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/stytchauth/stytch-go/v5/stytch"
 	"github.com/stytchauth/stytch-go/v5/stytch/stytcherror"
@@ -50,5 +51,50 @@ func (c *Client) Reset(
 
 	var retVal stytch.PasswordEmailResetResponse
 	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	return &retVal, err
+}
+
+// ResetWithClaims fills in the claims pointer with custom claims from the response.
+// Pass in a map with the types of values you're expecting so that this function can marshal
+// the claims from the response. See session_test.go for an example
+func (c *Client) ResetWithClaims(
+	body *stytch.PasswordEmailResetParams,
+	claims interface{},
+) (*stytch.PasswordEmailResetResponse, error) {
+	path := "/passwords/email/reset"
+
+	var jsonBody []byte
+	var err error
+	if body != nil {
+		jsonBody, err = json.Marshal(body)
+		if err != nil {
+			return nil, stytcherror.NewClientLibraryError(
+				"Oops, something seems to have gone wrong " +
+					"marshalling the /passwords/email/reset request body")
+		}
+	}
+
+	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// First extract the Stytch data.
+	var retVal stytch.PasswordEmailResetResponse
+	if err := json.Unmarshal(b, &retVal); err != nil {
+		return nil, fmt.Errorf("unmarshal PasswordEmailResetResponse: %w", err)
+	}
+
+	// Then extract the custom claims. Build a claims wrapper using the caller's `claims` value so
+	// the unmarshal fills it.
+	wrapper := stytch.SessionWrapper{
+		Session: stytch.ClaimsWrapper{
+			Claims: claims,
+		},
+	}
+	if err := json.Unmarshal(b, &wrapper); err != nil {
+		return nil, fmt.Errorf("unmarshal custom claims: %w", err)
+	}
+	retVal.Session.CustomClaims = wrapper.Session.Claims
 	return &retVal, err
 }

--- a/stytch/password/email/email.go
+++ b/stytch/password/email/email.go
@@ -56,7 +56,8 @@ func (c *Client) Reset(
 
 // ResetWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See session_test.go for an example
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) ResetWithClaims(
 	body *stytch.PasswordEmailResetParams,
 	claims interface{},

--- a/stytch/password/password.go
+++ b/stytch/password/password.go
@@ -37,7 +37,8 @@ func (c *Client) Create(
 
 // CreateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See session_test.go for an example
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) CreateWithClaims(
 	body *stytch.PasswordsCreateParams,
 	claims interface{},
@@ -103,7 +104,8 @@ func (c *Client) Authenticate(
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See session_test.go for an example
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.PasswordsAuthenticateParams,
 	claims interface{},

--- a/stytch/password/password.go
+++ b/stytch/password/password.go
@@ -37,7 +37,7 @@ func (c *Client) Create(
 
 // CreateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) CreateWithClaims(
 	body *stytch.PasswordsCreateParams,
@@ -104,7 +104,7 @@ func (c *Client) Authenticate(
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.PasswordsAuthenticateParams,

--- a/stytch/session.go
+++ b/stytch/session.go
@@ -37,9 +37,10 @@ type Key struct {
 }
 
 type SessionsAuthenticateParams struct {
-	SessionToken           string `json:"session_token,omitempty"`
-	SessionDurationMinutes int32  `json:"session_duration_minutes,omitempty"`
-	SessionJWT             string `json:"session_jwt,omitempty"`
+	SessionToken           string                 `json:"session_token,omitempty"`
+	SessionDurationMinutes int32                  `json:"session_duration_minutes,omitempty"`
+	SessionJWT             string                 `json:"session_jwt,omitempty"`
+	SessionCustomClaims    map[string]interface{} `json:"session_custom_claims,omitempty"`
 }
 
 type SessionsAuthenticateResponse struct {

--- a/stytch/session/session.go
+++ b/stytch/session/session.go
@@ -150,7 +150,8 @@ func (c *Client) Authenticate(
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See session_test.go for an example
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.SessionsAuthenticateParams,
 	claims interface{},

--- a/stytch/session/session.go
+++ b/stytch/session/session.go
@@ -150,7 +150,7 @@ func (c *Client) Authenticate(
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.SessionsAuthenticateParams,

--- a/stytch/session/session.go
+++ b/stytch/session/session.go
@@ -148,6 +148,9 @@ func (c *Client) Authenticate(
 	return &retVal, err
 }
 
+// AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
+// Pass in a map with the types of values you're expecting so that this function can marshal
+// the claims from the response. See session_test.go for an example
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.SessionsAuthenticateParams,
 	claims interface{},

--- a/stytch/totp.go
+++ b/stytch/totp.go
@@ -21,11 +21,12 @@ type TOTPsCreateResponse struct {
 }
 
 type TOTPsAuthenticateParams struct {
-	UserID                 string `json:"user_id"`
-	TOTPCode               string `json:"totp_code"`
-	SessionToken           string `json:"session_token,omitempty"`
-	SessionJWT             string `json:"session_jwt,omitempty"`
-	SessionDurationMinutes int32  `json:"session_duration_minutes,omitempty"`
+	UserID                 string                 `json:"user_id"`
+	TOTPCode               string                 `json:"totp_code"`
+	SessionToken           string                 `json:"session_token,omitempty"`
+	SessionJWT             string                 `json:"session_jwt,omitempty"`
+	SessionDurationMinutes int32                  `json:"session_duration_minutes,omitempty"`
+	SessionCustomClaims    map[string]interface{} `json:"session_custom_claims,omitempty"`
 }
 
 type TOTPsAuthenticateResponse struct {
@@ -51,11 +52,12 @@ type TOTPsRecoveryCodesResponse struct {
 }
 
 type TOTPsRecoverParams struct {
-	UserID                 string `json:"user_id"`
-	RecoveryCode           string `json:"recovery_code"`
-	SessionToken           string `json:"session_token,omitempty"`
-	SessionJWT             string `json:"session_jwt,omitempty"`
-	SessionDurationMinutes int32  `json:"session_duration_minutes,omitempty"`
+	UserID                 string                 `json:"user_id"`
+	RecoveryCode           string                 `json:"recovery_code"`
+	SessionToken           string                 `json:"session_token,omitempty"`
+	SessionJWT             string                 `json:"session_jwt,omitempty"`
+	SessionDurationMinutes int32                  `json:"session_duration_minutes,omitempty"`
+	SessionCustomClaims    map[string]interface{} `json:"session_custom_claims,omitempty"`
 }
 
 type TOTPsRecoverResponse struct {

--- a/stytch/totp/totp.go
+++ b/stytch/totp/totp.go
@@ -56,7 +56,7 @@ func (c *Client) Authenticate(body *stytch.TOTPsAuthenticateParams) (
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.TOTPsAuthenticateParams,
@@ -146,7 +146,7 @@ func (c *Client) Recover(body *stytch.TOTPsRecoverParams) (
 
 // RecoverWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) RecoverWithClaims(
 	body *stytch.TOTPsRecoverParams,

--- a/stytch/totp/totp.go
+++ b/stytch/totp/totp.go
@@ -56,7 +56,8 @@ func (c *Client) Authenticate(body *stytch.TOTPsAuthenticateParams) (
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See session_test.go for an example
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.TOTPsAuthenticateParams,
 	claims interface{},
@@ -145,7 +146,8 @@ func (c *Client) Recover(body *stytch.TOTPsRecoverParams) (
 
 // RecoverWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See session_test.go for an example
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) RecoverWithClaims(
 	body *stytch.TOTPsRecoverParams,
 	claims interface{},

--- a/stytch/totp/totp.go
+++ b/stytch/totp/totp.go
@@ -54,6 +54,9 @@ func (c *Client) Authenticate(body *stytch.TOTPsAuthenticateParams) (
 	return &retVal, err
 }
 
+// AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
+// Pass in a map with the types of values you're expecting so that this function can marshal
+// the claims from the response. See session_test.go for an example
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.TOTPsAuthenticateParams,
 	claims interface{},
@@ -140,6 +143,9 @@ func (c *Client) Recover(body *stytch.TOTPsRecoverParams) (
 	return &retVal, err
 }
 
+// RecoverWithClaims fills in the claims pointer with custom claims from the response.
+// Pass in a map with the types of values you're expecting so that this function can marshal
+// the claims from the response. See session_test.go for an example
 func (c *Client) RecoverWithClaims(
 	body *stytch.TOTPsRecoverParams,
 	claims interface{},

--- a/stytch/webauthn.go
+++ b/stytch/webauthn.go
@@ -39,10 +39,11 @@ type WebAuthnAuthenticateStartResponse struct {
 }
 
 type WebAuthnAuthenticateParams struct {
-	PublicKeyCredential    string `json:"public_key_credential,omitempty"`
-	SessionToken           string `json:"session_token,omitempty"`
-	SessionJWT             string `json:"session_jwt,omitempty"`
-	SessionDurationMinutes int32  `json:"session_duration_minutes,omitempty"`
+	PublicKeyCredential    string                 `json:"public_key_credential,omitempty"`
+	SessionToken           string                 `json:"session_token,omitempty"`
+	SessionJWT             string                 `json:"session_jwt,omitempty"`
+	SessionDurationMinutes int32                  `json:"session_duration_minutes,omitempty"`
+	SessionCustomClaims    map[string]interface{} `json:"session_custom_claims,omitempty"`
 }
 
 type WebAuthnAuthenticateResponse struct {

--- a/stytch/webauthn/webauthn.go
+++ b/stytch/webauthn/webauthn.go
@@ -90,7 +90,8 @@ func (c *Client) Authenticate(body *stytch.WebAuthnAuthenticateParams,
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See session_test.go for an example
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.WebAuthnAuthenticateParams,
 	claims interface{},

--- a/stytch/webauthn/webauthn.go
+++ b/stytch/webauthn/webauthn.go
@@ -88,6 +88,9 @@ func (c *Client) Authenticate(body *stytch.WebAuthnAuthenticateParams,
 	return &retVal, err
 }
 
+// AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
+// Pass in a map with the types of values you're expecting so that this function can marshal
+// the claims from the response. See session_test.go for an example
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.WebAuthnAuthenticateParams,
 	claims interface{},

--- a/stytch/webauthn/webauthn.go
+++ b/stytch/webauthn/webauthn.go
@@ -90,7 +90,7 @@ func (c *Client) Authenticate(body *stytch.WebAuthnAuthenticateParams,
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
 // Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map, 
+// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
 	body *stytch.WebAuthnAuthenticateParams,


### PR DESCRIPTION
- Add custom claims map to authenticate requests
- Add comments clarifying use of `claims interface{}` arguments in `AuthenticateWithClaims` functions
- Support custom claims for passwords