### PR TITLE
Add user fields to TOTP create response

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.13.0"
+const APIVersion = "5.14.0"
 
 type BaseURI string
 

--- a/stytch/totp.go
+++ b/stytch/totp.go
@@ -18,6 +18,8 @@ type TOTPsCreateResponse struct {
 	TOTPID        string   `json:"totp_id,omitempty"`
 	QRCode        string   `json:"qr_code,omitempty"`
 	RecoveryCodes []string `json:"recovery_codes,omitempty"`
+	User          User     `json:"user,omitempty"`
+	UserID        string   `json:"user_id,omitempty"`
 }
 
 type TOTPsAuthenticateParams struct {


### PR DESCRIPTION
The TOTP create endpoint now returns a user ID and user field. This PR adds these fields to `TOTPsCreateResponse` in the Go client library.