### PR TITLE
BACK-1935 ML/OTP send attach method params

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.14.2"
+const APIVersion = "5.15.0"
 
 type BaseURI string
 

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "5.14.1"
+const APIVersion = "5.14.2"
 
 type BaseURI string
 

--- a/stytch/magiclink.go
+++ b/stytch/magiclink.go
@@ -45,6 +45,9 @@ type MagicLinksEmailSendParams struct {
 	SignupExpirationMinutes int32      `json:"signup_expiration_minutes,omitempty"`
 	Attributes              Attributes `json:"attributes,omitempty"`
 	CodeChallenge           string     `json:"code_challenge,omitempty"`
+	UserID                  string     `json:"user_id,omitempty"`
+	SessionToken            string     `json:"session_token,omitempty"`
+	SessionJWT              string     `json:"session_jwt,omitempty"`
 }
 
 type MagicLinksEmailSendResponse struct {

--- a/stytch/otp.go
+++ b/stytch/otp.go
@@ -28,6 +28,9 @@ type OTPsSMSSendParams struct {
 	PhoneNumber       string     `json:"phone_number"`
 	ExpirationMinutes int32      `json:"expiration_minutes,omitempty"`
 	Attributes        Attributes `json:"attributes,omitempty"`
+	UserID            string     `json:"user_id,omitempty"`
+	SessionToken      string     `json:"session_token,omitempty"`
+	SessionJWT        string     `json:"session_jwt,omitempty"`
 }
 
 type OTPsSMSSendResponse struct {
@@ -57,6 +60,9 @@ type OTPsWhatsAppSendParams struct {
 	PhoneNumber       string     `json:"phone_number"`
 	ExpirationMinutes int32      `json:"expiration_minutes,omitempty"`
 	Attributes        Attributes `json:"attributes,omitempty"`
+	UserID            string     `json:"user_id,omitempty"`
+	SessionToken      string     `json:"session_token,omitempty"`
+	SessionJWT        string     `json:"session_jwt,omitempty"`
 }
 
 type OTPsWhatsAppSendResponse struct {
@@ -86,6 +92,9 @@ type OTPsEmailSendParams struct {
 	Email             string     `json:"email"`
 	ExpirationMinutes int32      `json:"expiration_minutes,omitempty"`
 	Attributes        Attributes `json:"attributes,omitempty"`
+	UserID            string     `json:"user_id,omitempty"`
+	SessionToken      string     `json:"session_token,omitempty"`
+	SessionJWT        string     `json:"session_jwt,omitempty"`
 }
 
 type OTPsEmailSendResponse struct {


### PR DESCRIPTION
We have optional user_id, session_token, and session_jwt arguments for magic links email send, OTP email/sms/whatsapp send now to attach the delivery method to a user.