### PR TITLE
[SUP-11] Add locale parameter to Email Magic Links, OTP, and Passwords endpoints

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "6.2.0"
+const APIVersion = "6.3.0"
 
 type BaseURI string
 

--- a/stytch/magiclink.go
+++ b/stytch/magiclink.go
@@ -48,6 +48,7 @@ type MagicLinksEmailSendParams struct {
 	UserID                  string     `json:"user_id,omitempty"`
 	SessionToken            string     `json:"session_token,omitempty"`
 	SessionJWT              string     `json:"session_jwt,omitempty"`
+	Locale                  string     `json:"locale,omitempty"`
 }
 
 type MagicLinksEmailSendResponse struct {
@@ -66,6 +67,7 @@ type MagicLinksEmailLoginOrCreateParams struct {
 	CreateUserAsPending     bool       `json:"create_user_as_pending,omitempty"`
 	Attributes              Attributes `json:"attributes,omitempty"`
 	CodeChallenge           string     `json:"code_challenge,omitempty"`
+	Locale                  string     `json:"locale,omitempty"`
 }
 
 type MagicLinksEmailLoginOrCreateResponse struct {
@@ -82,6 +84,7 @@ type MagicLinksEmailInviteParams struct {
 	InviteExpirationMinutes int32      `json:"invite_expiration_minutes,omitempty"`
 	Name                    Name       `json:"name,omitempty"`
 	Attributes              Attributes `json:"attributes,omitempty"`
+	Locale                  string     `json:"locale,omitempty"`
 }
 
 type MagicLinksEmailInviteResponse struct {

--- a/stytch/otp.go
+++ b/stytch/otp.go
@@ -31,6 +31,7 @@ type OTPsSMSSendParams struct {
 	UserID            string     `json:"user_id,omitempty"`
 	SessionToken      string     `json:"session_token,omitempty"`
 	SessionJWT        string     `json:"session_jwt,omitempty"`
+	Locale            string     `json:"locale,omitempty"`
 }
 
 type OTPsSMSSendResponse struct {
@@ -45,6 +46,7 @@ type OTPsSMSLoginOrCreateParams struct {
 	ExpirationMinutes   int32      `json:"expiration_minutes,omitempty"`
 	Attributes          Attributes `json:"attributes,omitempty"`
 	CreateUserAsPending bool       `json:"create_user_as_pending,omitempty"`
+	Locale              string     `json:"locale,omitempty"`
 }
 
 type OTPsSMSLoginOrCreateResponse struct {
@@ -63,6 +65,7 @@ type OTPsWhatsAppSendParams struct {
 	UserID            string     `json:"user_id,omitempty"`
 	SessionToken      string     `json:"session_token,omitempty"`
 	SessionJWT        string     `json:"session_jwt,omitempty"`
+	Locale            string     `json:"locale,omitempty"`
 }
 
 type OTPsWhatsAppSendResponse struct {
@@ -77,6 +80,7 @@ type OTPsWhatsAppLoginOrCreateParams struct {
 	ExpirationMinutes   int32      `json:"expiration_minutes,omitempty"`
 	Attributes          Attributes `json:"attributes,omitempty"`
 	CreateUserAsPending bool       `json:"create_user_as_pending,omitempty"`
+	Locale              string     `json:"locale,omitempty"`
 }
 
 type OTPsWhatsAppLoginOrCreateResponse struct {
@@ -95,6 +99,7 @@ type OTPsEmailSendParams struct {
 	UserID            string     `json:"user_id,omitempty"`
 	SessionToken      string     `json:"session_token,omitempty"`
 	SessionJWT        string     `json:"session_jwt,omitempty"`
+	Locale            string     `json:"locale,omitempty"`
 }
 
 type OTPsEmailSendResponse struct {
@@ -109,6 +114,7 @@ type OTPsEmailLoginOrCreateParams struct {
 	ExpirationMinutes   int32      `json:"expiration_minutes,omitempty"`
 	Attributes          Attributes `json:"attributes,omitempty"`
 	CreateUserAsPending bool       `json:"create_user_as_pending,omitempty"`
+	Locale              string     `json:"locale,omitempty"`
 }
 
 type OTPsEmailLoginOrCreateResponse struct {

--- a/stytch/password.go
+++ b/stytch/password.go
@@ -119,6 +119,7 @@ type PasswordEmailResetStartParams struct {
 	ResetPasswordExpirationMinutes int32      `json:"reset_password_expiration_minutes,omitempty"`
 	Attributes                     Attributes `json:"attributes,omitempty"`
 	CodeChallenge                  string     `json:"code_challenge,omitempty"`
+	Locale                         string     `json:"locale,omitempty"`
 }
 
 type PasswordEmailResetStartResponse struct {


### PR DESCRIPTION
### Description
Adds support for the optional `locale` parameter for the following endpoints:

- /magic_links/email/send
- /magic_links/email/login_or_create
- /magic_links/email/invite
- /otps/email/send
- /otps/email/login_or_create
- /otps/sms/send
- /otps/sms/login_or_create
- /otps/whatsapp/send
- /otps/whatsapp/login_or_create
- /passwords/email/reset/start

The locale parameter specifies the text language of the email that the user receives. Current `locale` options are "en" (English) and "es" (Spanish).
### Dependencies
Support for the `locale` parameter has already been added to Stytch's API endpoints.