### PR TITLE
feat: Add support for OAuth Attach endpoint

### DIFF
--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "6.3.0"
+const APIVersion = "6.4.0"
 
 type BaseURI string
 

--- a/stytch/oauth.go
+++ b/stytch/oauth.go
@@ -57,7 +57,9 @@ type ProviderValues struct {
 }
 
 type OAuthAttachParams struct {
-	Provider     string `json:"provider,omitempty"`
+	Provider string `json:"provider,omitempty"`
+
+	// Exactly one of UserID, SessionToken, and SessionJWT must be populated.
 	UserID       string `json:"user_id,omitempty"`
 	SessionToken string `json:"session_token,omitempty"`
 	SessionJWT   string `json:"session_jwt,omitempty"`

--- a/stytch/oauth.go
+++ b/stytch/oauth.go
@@ -55,3 +55,16 @@ type ProviderValues struct {
 	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
 	Scopes       []string   `json:"scopes,omitempty"`
 }
+
+type OAuthAttachParams struct {
+	Provider     string `json:"provider,omitempty"`
+	UserID       string `json:"user_id,omitempty"`
+	SessionToken string `json:"session_token,omitempty"`
+	SessionJWT   string `json:"session_jwt,omitempty"`
+}
+
+type OAuthAttachResponse struct {
+	RequestID        string `json:"request_id,omitempty"`
+	StatusCode       int    `json:"status_code,omitempty"`
+	OAuthAttachToken string `json:"oauth_attach_token,omitempty"`
+}

--- a/stytch/oauth/oauth.go
+++ b/stytch/oauth/oauth.go
@@ -80,3 +80,24 @@ func (c *Client) AuthenticateWithClaims(
 	retVal.Session.CustomClaims = wrapper.Session.Claims
 	return &retVal, err
 }
+
+func (c *Client) Attach(
+	body *stytch.OAuthAttachParams,
+) (*stytch.OAuthAttachResponse, error) {
+	path := "/oauth/attach"
+
+	var jsonBody []byte
+	var err error
+	if body != nil {
+		jsonBody, err = json.Marshal(body)
+		if err != nil {
+			return nil, stytcherror.NewClientLibraryError(
+				"Oops, something seems to have gone wrong " +
+					"marshalling the /oauth/attach request body")
+		}
+	}
+
+	var retVal stytch.OAuthAttachResponse
+	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	return &retVal, err
+}


### PR DESCRIPTION
This adds support for an upcoming endpoint: OAuth Attach (`/v1/oauth/attach`).
