### PR TITLE
fix: missing Password field in UsersGetResponse

### DIFF
--- a/stytch/user.go
+++ b/stytch/user.go
@@ -99,6 +99,7 @@ type UsersGetResponse struct {
 	WebAuthnRegistrations []WebAuthnRegistration `json:"webauthn_registrations,omitempty"`
 	OAuthProviders        []OAuthProvider        `json:"providers,omitempty"`
 	TOTPs                 []UserTOTP             `json:"totps,omitempty"`
+	Password              Password               `json:"password,omitempty"`
 	CryptoWallets         []CryptoWallet         `json:"crypto_wallets,omitempty"`
 	Status                string                 `json:"status,omitempty"`
 	CreatedAt             time.Time              `json:"created_at,omitempty"`


### PR DESCRIPTION
This PR adds the missing `Password` field to the `UsersGetResponse` struct. The `User` struct has included the field since a60aae2b34dc6ac0d32973f6453b2315c74bf0c0. The `UsersGetResponse` was not changed to include it in the referenced commit.