### PR TITLE
Add PHPass password hash type

### DIFF
--- a/stytch/password.go
+++ b/stytch/password.go
@@ -109,6 +109,7 @@ const (
 	HashTypeArgon2ID HashType = "argon_2id"
 	HashTypeSHA1     HashType = "sha_1"
 	HashTypeScrypt   HashType = "scrypt"
+	HashTypePHPass   HashType = "phpass"
 )
 
 // PASSWORD - EMAIL


### PR DESCRIPTION
This adds support for `phpass` hashes in the Password Migrate endpoint