### PR TITLE
Ag/2023 03 13 accept context

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,21 @@ if err != nil {
 
 Send a magic link by email:
 ```go
-	res, err := stytchAPIClient.MagicLinks.Email.Send(&stytch.MagicLinksEmailSendParams{
-		Email:              "sandbox@stytch.com",
-		Attributes:         stytch.Attributes{
-			IPAddress: "10.0.0.0",
-		},
-    })
+	res, err := stytchAPIClient.MagicLinks.Email.Send(
+		context.Background(),
+		&stytch.MagicLinksEmailSendParams{
+		    Email:              "sandbox@stytch.com",
+		    Attributes:         stytch.Attributes{
+			    IPAddress: "10.0.0.0",
+		    },
+        },
+    )
 ```
 
 Authenticate the token from the magic link:
 ```go
 	res, err := stytchAPIClient.MagicLinks.Authenticate(
+		context.Background(),
 		&stytch.MagicLinksAuthenticateParams{
 			Token:      "DOYoip3rvIMMW5lgItikFK-Ak1CfMsgjuiCyI7uuU94=",
 			Options:    stytch.Options{IPMatchRequired: true},
@@ -71,6 +75,7 @@ Authenticate the token from the magic link:
 Get all users
 ```go
     res, err := stytchAPIClient.Users.Search(
+		context.Background(),
 		&stytch.UsersSearchParams{
 			Limit: 1000	
 		})
@@ -79,6 +84,7 @@ Get all users
 Search users
 ```go
 	res, err := stytchAPIClient.Users.Search(
+		context.Background(),
 		&stytch.UsersSearchParams{
 			Limit: 1000,
 			Query: stytch.UsersSearchQuery{
@@ -97,7 +103,7 @@ Iterate over all pages of users for a search query
 	var users []stytch.User
 	iter := stytchAPIClient.Users.SearchAll(&stytch.UsersSearchParams{})
 	for iter.HasNext() {
-		res, err := iter.Next()
+		res, err := iter.Next(context.Background())
 		if err != nil {
 			fmt.Println(err)
 			return nil, err

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "6.5.3"
+const APIVersion = "7.0.0"
 
 type BaseURI string
 

--- a/stytch/cryptowallet/cryptowallet.go
+++ b/stytch/cryptowallet/cryptowallet.go
@@ -1,6 +1,7 @@
 package cryptowallet
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -12,7 +13,9 @@ type Client struct {
 	C *stytch.Client
 }
 
-func (c *Client) AuthenticateStart(body *stytch.CryptoWalletAuthenticateStartParams,
+func (c *Client) AuthenticateStart(
+	ctx context.Context,
+	body *stytch.CryptoWalletAuthenticateStartParams,
 ) (*stytch.CryptoWalletAuthenticateStartResponse, error) {
 	path := "/crypto_wallets/authenticate/start"
 
@@ -31,7 +34,9 @@ func (c *Client) AuthenticateStart(body *stytch.CryptoWalletAuthenticateStartPar
 	return &retVal, err
 }
 
-func (c *Client) Authenticate(body *stytch.CryptoWalletAuthenticateParams,
+func (c *Client) Authenticate(
+	ctx context.Context,
+	body *stytch.CryptoWalletAuthenticateParams,
 ) (*stytch.CryptoWalletAuthenticateResponse, error) {
 	path := "/crypto_wallets/authenticate"
 
@@ -55,6 +60,7 @@ func (c *Client) Authenticate(body *stytch.CryptoWalletAuthenticateParams,
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
+	ctx context.Context,
 	body *stytch.CryptoWalletAuthenticateParams,
 	claims interface{},
 ) (*stytch.CryptoWalletAuthenticateResponse, error) {

--- a/stytch/cryptowallet/cryptowallet.go
+++ b/stytch/cryptowallet/cryptowallet.go
@@ -27,7 +27,7 @@ func (c *Client) AuthenticateStart(body *stytch.CryptoWalletAuthenticateStartPar
 	}
 
 	var retVal stytch.CryptoWalletAuthenticateStartResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -46,7 +46,7 @@ func (c *Client) Authenticate(body *stytch.CryptoWalletAuthenticateParams,
 	}
 
 	var retVal stytch.CryptoWalletAuthenticateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -70,7 +70,7 @@ func (c *Client) AuthenticateWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}

--- a/stytch/magiclink/email/email.go
+++ b/stytch/magiclink/email/email.go
@@ -1,6 +1,7 @@
 package email
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/stytchauth/stytch-go/v6/stytch"
@@ -12,6 +13,7 @@ type Client struct {
 }
 
 func (c *Client) Send(
+	ctx context.Context,
 	body *stytch.MagicLinksEmailSendParams,
 ) (*stytch.MagicLinksEmailSendResponse, error) {
 	path := "/magic_links/email/send"
@@ -31,7 +33,10 @@ func (c *Client) Send(
 	return &retVal, err
 }
 
-func (c *Client) LoginOrCreate(body *stytch.MagicLinksEmailLoginOrCreateParams) (
+func (c *Client) LoginOrCreate(
+	ctx context.Context,
+	body *stytch.MagicLinksEmailLoginOrCreateParams,
+) (
 	*stytch.MagicLinksEmailLoginOrCreateResponse, error,
 ) {
 	path := "/magic_links/email/login_or_create"
@@ -52,6 +57,7 @@ func (c *Client) LoginOrCreate(body *stytch.MagicLinksEmailLoginOrCreateParams) 
 }
 
 func (c *Client) Invite(
+	ctx context.Context,
 	body *stytch.MagicLinksEmailInviteParams,
 ) (*stytch.MagicLinksEmailInviteResponse, error) {
 	path := "/magic_links/email/invite"
@@ -71,7 +77,10 @@ func (c *Client) Invite(
 	return &retVal, err
 }
 
-func (c *Client) RevokeInvite(body *stytch.MagicLinksEmailRevokeInviteParams) (
+func (c *Client) RevokeInvite(
+	ctx context.Context,
+	body *stytch.MagicLinksEmailRevokeInviteParams,
+) (
 	*stytch.MagicLinksEmailRevokeInviteResponse, error,
 ) {
 	path := "/magic_links/email/revoke_invite"

--- a/stytch/magiclink/email/email.go
+++ b/stytch/magiclink/email/email.go
@@ -27,7 +27,7 @@ func (c *Client) Send(
 	}
 
 	var retVal stytch.MagicLinksEmailSendResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -47,7 +47,7 @@ func (c *Client) LoginOrCreate(body *stytch.MagicLinksEmailLoginOrCreateParams) 
 	}
 
 	var retVal stytch.MagicLinksEmailLoginOrCreateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -67,7 +67,7 @@ func (c *Client) Invite(
 	}
 
 	var retVal stytch.MagicLinksEmailInviteResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -87,6 +87,6 @@ func (c *Client) RevokeInvite(body *stytch.MagicLinksEmailRevokeInviteParams) (
 	}
 
 	var retVal stytch.MagicLinksEmailRevokeInviteResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }

--- a/stytch/magiclink/magiclink.go
+++ b/stytch/magiclink/magiclink.go
@@ -1,6 +1,7 @@
 package magiclink
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -15,6 +16,7 @@ type Client struct {
 }
 
 func (c *Client) Create(
+	ctx context.Context,
 	body *stytch.MagicLinksCreateParams,
 ) (*stytch.MagicLinksCreateResponse, error) {
 	path := "/magic_links"
@@ -36,6 +38,7 @@ func (c *Client) Create(
 }
 
 func (c *Client) Authenticate(
+	ctx context.Context,
 	body *stytch.MagicLinksAuthenticateParams,
 ) (*stytch.MagicLinksAuthenticateResponse, error) {
 	path := "/magic_links/authenticate"
@@ -61,6 +64,7 @@ func (c *Client) Authenticate(
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
+	ctx context.Context,
 	body *stytch.MagicLinksAuthenticateParams,
 	claims interface{},
 ) (*stytch.MagicLinksAuthenticateResponse, error) {

--- a/stytch/magiclink/magiclink.go
+++ b/stytch/magiclink/magiclink.go
@@ -31,7 +31,7 @@ func (c *Client) Create(
 	}
 
 	var retVal stytch.MagicLinksCreateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -52,7 +52,7 @@ func (c *Client) Authenticate(
 	}
 
 	var retVal stytch.MagicLinksAuthenticateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -77,7 +77,7 @@ func (c *Client) AuthenticateWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}

--- a/stytch/oauth/oauth.go
+++ b/stytch/oauth/oauth.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -15,6 +16,7 @@ type Client struct {
 }
 
 func (c *Client) Authenticate(
+	ctx context.Context,
 	body *stytch.OAuthAuthenticateParams,
 ) (*stytch.OAuthAuthenticateResponse, error) {
 	path := "/oauth/authenticate"
@@ -40,6 +42,7 @@ func (c *Client) Authenticate(
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
+	ctx context.Context,
 	body *stytch.OAuthAuthenticateParams,
 	claims interface{},
 ) (*stytch.OAuthAuthenticateResponse, error) {
@@ -82,6 +85,7 @@ func (c *Client) AuthenticateWithClaims(
 }
 
 func (c *Client) Attach(
+	ctx context.Context,
 	body *stytch.OAuthAttachParams,
 ) (*stytch.OAuthAttachResponse, error) {
 	path := "/oauth/attach"

--- a/stytch/oauth/oauth.go
+++ b/stytch/oauth/oauth.go
@@ -31,7 +31,7 @@ func (c *Client) Authenticate(
 	}
 
 	var retVal stytch.OAuthAuthenticateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -56,7 +56,7 @@ func (c *Client) AuthenticateWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}
@@ -98,6 +98,6 @@ func (c *Client) Attach(
 	}
 
 	var retVal stytch.OAuthAttachResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }

--- a/stytch/otp/email/email.go
+++ b/stytch/otp/email/email.go
@@ -1,6 +1,7 @@
 package email
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/stytchauth/stytch-go/v6/stytch"
@@ -11,7 +12,10 @@ type Client struct {
 	C *stytch.Client
 }
 
-func (c *Client) Send(body *stytch.OTPsEmailSendParams) (*stytch.OTPsEmailSendResponse, error) {
+func (c *Client) Send(
+	ctx context.Context,
+	body *stytch.OTPsEmailSendParams,
+) (*stytch.OTPsEmailSendResponse, error) {
 	path := "/otps/email/send"
 
 	var jsonBody []byte
@@ -30,6 +34,7 @@ func (c *Client) Send(body *stytch.OTPsEmailSendParams) (*stytch.OTPsEmailSendRe
 }
 
 func (c *Client) LoginOrCreate(
+	ctx context.Context,
 	body *stytch.OTPsEmailLoginOrCreateParams,
 ) (*stytch.OTPsEmailLoginOrCreateResponse, error) {
 	path := "/otps/email/login_or_create"

--- a/stytch/otp/email/email.go
+++ b/stytch/otp/email/email.go
@@ -25,7 +25,7 @@ func (c *Client) Send(body *stytch.OTPsEmailSendParams) (*stytch.OTPsEmailSendRe
 	}
 
 	var retVal stytch.OTPsEmailSendResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -45,6 +45,6 @@ func (c *Client) LoginOrCreate(
 	}
 
 	var retVal stytch.OTPsEmailLoginOrCreateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }

--- a/stytch/otp/otp.go
+++ b/stytch/otp/otp.go
@@ -34,7 +34,7 @@ func (c *Client) Authenticate(
 	}
 
 	var retVal stytch.OTPsAuthenticateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -58,7 +58,7 @@ func (c *Client) AuthenticateWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}

--- a/stytch/otp/otp.go
+++ b/stytch/otp/otp.go
@@ -1,6 +1,7 @@
 package otp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -19,6 +20,7 @@ type Client struct {
 }
 
 func (c *Client) Authenticate(
+	ctx context.Context,
 	body *stytch.OTPsAuthenticateParams,
 ) (*stytch.OTPsAuthenticateResponse, error) {
 	path := "/otps/authenticate"
@@ -43,6 +45,7 @@ func (c *Client) Authenticate(
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
+	ctx context.Context,
 	body *stytch.OTPsAuthenticateParams,
 	claims interface{},
 ) (*stytch.OTPsAuthenticateResponse, error) {

--- a/stytch/otp/sms/sms.go
+++ b/stytch/otp/sms/sms.go
@@ -1,6 +1,7 @@
 package sms
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/stytchauth/stytch-go/v6/stytch"
@@ -11,7 +12,7 @@ type Client struct {
 	C *stytch.Client
 }
 
-func (c *Client) Send(body *stytch.OTPsSMSSendParams) (*stytch.OTPsSMSSendResponse, error) {
+func (c *Client) Send(ctx context.Context, body *stytch.OTPsSMSSendParams) (*stytch.OTPsSMSSendResponse, error) {
 	path := "/otps/sms/send"
 
 	var jsonBody []byte
@@ -30,7 +31,7 @@ func (c *Client) Send(body *stytch.OTPsSMSSendParams) (*stytch.OTPsSMSSendRespon
 }
 
 func (c *Client) LoginOrCreate(
-	body *stytch.OTPsSMSLoginOrCreateParams,
+	ctx context.Context, body *stytch.OTPsSMSLoginOrCreateParams,
 ) (*stytch.OTPsSMSLoginOrCreateResponse, error) {
 	path := "/otps/sms/login_or_create"
 

--- a/stytch/otp/sms/sms.go
+++ b/stytch/otp/sms/sms.go
@@ -12,7 +12,10 @@ type Client struct {
 	C *stytch.Client
 }
 
-func (c *Client) Send(ctx context.Context, body *stytch.OTPsSMSSendParams) (*stytch.OTPsSMSSendResponse, error) {
+func (c *Client) Send(
+	ctx context.Context,
+	body *stytch.OTPsSMSSendParams,
+) (*stytch.OTPsSMSSendResponse, error) {
 	path := "/otps/sms/send"
 
 	var jsonBody []byte
@@ -31,7 +34,8 @@ func (c *Client) Send(ctx context.Context, body *stytch.OTPsSMSSendParams) (*sty
 }
 
 func (c *Client) LoginOrCreate(
-	ctx context.Context, body *stytch.OTPsSMSLoginOrCreateParams,
+	ctx context.Context,
+	body *stytch.OTPsSMSLoginOrCreateParams,
 ) (*stytch.OTPsSMSLoginOrCreateResponse, error) {
 	path := "/otps/sms/login_or_create"
 

--- a/stytch/otp/sms/sms.go
+++ b/stytch/otp/sms/sms.go
@@ -25,7 +25,7 @@ func (c *Client) Send(body *stytch.OTPsSMSSendParams) (*stytch.OTPsSMSSendRespon
 	}
 
 	var retVal stytch.OTPsSMSSendResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -45,6 +45,6 @@ func (c *Client) LoginOrCreate(
 	}
 
 	var retVal stytch.OTPsSMSLoginOrCreateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }

--- a/stytch/otp/whatsapp/whatsapp.go
+++ b/stytch/otp/whatsapp/whatsapp.go
@@ -1,6 +1,7 @@
 package whatsapp
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/stytchauth/stytch-go/v6/stytch"
@@ -11,7 +12,9 @@ type Client struct {
 	C *stytch.Client
 }
 
-func (c *Client) Send(body *stytch.OTPsWhatsAppSendParams,
+func (c *Client) Send(
+	ctx context.Context,
+	body *stytch.OTPsWhatsAppSendParams,
 ) (*stytch.OTPsWhatsAppSendResponse, error) {
 	path := "/otps/whatsapp/send"
 
@@ -30,7 +33,9 @@ func (c *Client) Send(body *stytch.OTPsWhatsAppSendParams,
 	return &retVal, err
 }
 
-func (c *Client) LoginOrCreate(body *stytch.OTPsWhatsAppLoginOrCreateParams,
+func (c *Client) LoginOrCreate(
+	ctx context.Context,
+	body *stytch.OTPsWhatsAppLoginOrCreateParams,
 ) (*stytch.OTPsWhatsAppLoginOrCreateResponse, error) {
 	path := "/otps/whatsapp/login_or_create"
 

--- a/stytch/otp/whatsapp/whatsapp.go
+++ b/stytch/otp/whatsapp/whatsapp.go
@@ -26,7 +26,7 @@ func (c *Client) Send(body *stytch.OTPsWhatsAppSendParams,
 	}
 
 	var retVal stytch.OTPsWhatsAppSendResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -45,6 +45,6 @@ func (c *Client) LoginOrCreate(body *stytch.OTPsWhatsAppLoginOrCreateParams,
 	}
 
 	var retVal stytch.OTPsWhatsAppLoginOrCreateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }

--- a/stytch/password/email/email.go
+++ b/stytch/password/email/email.go
@@ -1,6 +1,7 @@
 package email
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -13,6 +14,7 @@ type Client struct {
 }
 
 func (c *Client) ResetStart(
+	ctx context.Context,
 	body *stytch.PasswordEmailResetStartParams,
 ) (*stytch.PasswordEmailResetStartResponse, error) {
 	path := "/passwords/email/reset/start"
@@ -34,6 +36,7 @@ func (c *Client) ResetStart(
 }
 
 func (c *Client) Reset(
+	ctx context.Context,
 	body *stytch.PasswordEmailResetParams,
 ) (*stytch.PasswordEmailResetResponse, error) {
 	path := "/passwords/email/reset"
@@ -59,6 +62,7 @@ func (c *Client) Reset(
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) ResetWithClaims(
+	ctx context.Context,
 	body *stytch.PasswordEmailResetParams,
 	claims interface{},
 ) (*stytch.PasswordEmailResetResponse, error) {

--- a/stytch/password/email/email.go
+++ b/stytch/password/email/email.go
@@ -29,7 +29,7 @@ func (c *Client) ResetStart(
 	}
 
 	var retVal stytch.PasswordEmailResetStartResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -50,7 +50,7 @@ func (c *Client) Reset(
 	}
 
 	var retVal stytch.PasswordEmailResetResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -75,7 +75,7 @@ func (c *Client) ResetWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}

--- a/stytch/password/existingpassword/existingpassword.go
+++ b/stytch/password/existingpassword/existingpassword.go
@@ -29,7 +29,7 @@ func (c *Client) Reset(
 	}
 
 	var retVal stytch.PasswordExistingPasswordResetResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -54,7 +54,7 @@ func (c *Client) ResetWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}

--- a/stytch/password/existingpassword/existingpassword.go
+++ b/stytch/password/existingpassword/existingpassword.go
@@ -1,6 +1,7 @@
 package existingpassword
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -13,6 +14,7 @@ type Client struct {
 }
 
 func (c *Client) Reset(
+	ctx context.Context,
 	body *stytch.PasswordExistingPasswordResetParams,
 ) (*stytch.PasswordExistingPasswordResetResponse, error) {
 	path := "/passwords/existing_password/reset"
@@ -38,6 +40,7 @@ func (c *Client) Reset(
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) ResetWithClaims(
+	ctx context.Context,
 	body *stytch.PasswordExistingPasswordResetParams,
 	claims interface{},
 ) (*stytch.PasswordExistingPasswordResetResponse, error) {

--- a/stytch/password/password.go
+++ b/stytch/password/password.go
@@ -1,6 +1,7 @@
 package password
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -19,6 +20,7 @@ type Client struct {
 }
 
 func (c *Client) Create(
+	ctx context.Context,
 	body *stytch.PasswordsCreateParams,
 ) (*stytch.PasswordsCreateResponse, error) {
 	path := "/passwords"
@@ -44,6 +46,7 @@ func (c *Client) Create(
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) CreateWithClaims(
+	ctx context.Context,
 	body *stytch.PasswordsCreateParams,
 	claims interface{},
 ) (*stytch.PasswordsCreateResponse, error) {
@@ -86,6 +89,7 @@ func (c *Client) CreateWithClaims(
 }
 
 func (c *Client) Authenticate(
+	ctx context.Context,
 	body *stytch.PasswordsAuthenticateParams,
 ) (*stytch.PasswordsAuthenticateResponse, error) {
 	path := "/passwords/authenticate"
@@ -111,6 +115,7 @@ func (c *Client) Authenticate(
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
+	ctx context.Context,
 	body *stytch.PasswordsAuthenticateParams,
 	claims interface{},
 ) (*stytch.PasswordsAuthenticateResponse, error) {
@@ -153,6 +158,7 @@ func (c *Client) AuthenticateWithClaims(
 }
 
 func (c *Client) StrengthCheck(
+	ctx context.Context,
 	body *stytch.PasswordsStrengthCheckParams,
 ) (*stytch.PasswordsStrengthCheckResponse, error) {
 	path := "/passwords/strength_check"
@@ -174,6 +180,7 @@ func (c *Client) StrengthCheck(
 }
 
 func (c *Client) Migrate(
+	ctx context.Context,
 	body *stytch.PasswordsMigrateParams,
 ) (*stytch.PasswordsMigrateResponse, error) {
 	path := "/passwords/migrate"

--- a/stytch/password/password.go
+++ b/stytch/password/password.go
@@ -35,7 +35,7 @@ func (c *Client) Create(
 	}
 
 	var retVal stytch.PasswordsCreateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -60,7 +60,7 @@ func (c *Client) CreateWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (c *Client) Authenticate(
 	}
 
 	var retVal stytch.PasswordsAuthenticateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -127,7 +127,7 @@ func (c *Client) AuthenticateWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (c *Client) StrengthCheck(
 	}
 
 	var retVal stytch.PasswordsStrengthCheckResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -190,6 +190,6 @@ func (c *Client) Migrate(
 	}
 
 	var retVal stytch.PasswordsMigrateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }

--- a/stytch/password/session/session.go
+++ b/stytch/password/session/session.go
@@ -28,6 +28,6 @@ func (c *Client) Reset(
 	}
 
 	var retVal stytch.PasswordSessionResetResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }

--- a/stytch/password/session/session.go
+++ b/stytch/password/session/session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/stytchauth/stytch-go/v6/stytch"
@@ -12,6 +13,7 @@ type Client struct {
 }
 
 func (c *Client) Reset(
+	ctx context.Context,
 	body *stytch.PasswordSessionResetParams,
 ) (*stytch.PasswordSessionResetResponse, error) {
 	path := "/passwords/session/reset"

--- a/stytch/session/session.go
+++ b/stytch/session/session.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,6 +21,7 @@ type Client struct {
 }
 
 func (c *Client) Get(
+	ctx context.Context,
 	body *stytch.SessionsGetParams,
 ) (*stytch.SessionsGetResponse, error) {
 	queryParams := make(map[string]string)
@@ -33,7 +35,7 @@ func (c *Client) Get(
 }
 
 func (c *Client) GetJWKS(
-	body *stytch.SessionsGetJWKSParams,
+	ctx context.Context, body *stytch.SessionsGetJWKSParams,
 ) (*stytch.SessionsGetJWKSResponse, error) {
 	path := "/sessions/jwks/" + body.ProjectID
 
@@ -43,17 +45,18 @@ func (c *Client) GetJWKS(
 }
 
 func (c *Client) AuthenticateJWT(
+	ctx context.Context,
 	maxTokenAge time.Duration,
 	body *stytch.SessionsAuthenticateParams,
 ) (*stytch.SessionsAuthenticateResponse, error) {
 	if body.SessionJWT == "" || maxTokenAge == time.Duration(0) {
-		return c.Authenticate(body)
+		return c.Authenticate(ctx, body)
 	}
 
 	session, err := c.AuthenticateJWTLocal(body.SessionJWT, maxTokenAge)
 	if err != nil {
 		// JWT couldn't be verified locally. Check with the Stytch API.
-		return c.Authenticate(body)
+		return c.Authenticate(ctx, body)
 	}
 
 	return &stytch.SessionsAuthenticateResponse{
@@ -62,18 +65,19 @@ func (c *Client) AuthenticateJWT(
 }
 
 func (c *Client) AuthenticateJWTWithClaims(
+	ctx context.Context,
 	maxTokenAge time.Duration,
 	body *stytch.SessionsAuthenticateParams,
 	claims interface{},
 ) (*stytch.SessionsAuthenticateResponse, error) {
 	if body.SessionJWT == "" || maxTokenAge == time.Duration(0) {
-		return c.AuthenticateWithClaims(body, claims)
+		return c.AuthenticateWithClaims(ctx, body, claims)
 	}
 
 	session, err := c.AuthenticateJWTLocal(body.SessionJWT, maxTokenAge)
 	if err != nil {
 		// JWT couldn't be verified locally. Check with the Stytch API.
-		return c.Authenticate(body)
+		return c.Authenticate(ctx, body)
 	}
 
 	return &stytch.SessionsAuthenticateResponse{
@@ -129,6 +133,7 @@ func marshalJWTIntoSession(claims stytch.Claims) stytch.Session {
 }
 
 func (c *Client) Authenticate(
+	ctx context.Context,
 	body *stytch.SessionsAuthenticateParams,
 ) (*stytch.SessionsAuthenticateResponse, error) {
 	path := "/sessions/authenticate"
@@ -153,6 +158,7 @@ func (c *Client) Authenticate(
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
+	ctx context.Context,
 	body *stytch.SessionsAuthenticateParams,
 	claims interface{},
 ) (*stytch.SessionsAuthenticateResponse, error) {
@@ -194,6 +200,7 @@ func (c *Client) AuthenticateWithClaims(
 }
 
 func (c *Client) Revoke(
+	ctx context.Context,
 	body *stytch.SessionsRevokeParams,
 ) (*stytch.SessionsRevokeResponse, error) {
 	path := "/sessions/revoke"

--- a/stytch/session/session.go
+++ b/stytch/session/session.go
@@ -28,7 +28,7 @@ func (c *Client) Get(
 	}
 
 	var retVal stytch.SessionsGetResponse
-	err := c.C.NewRequest("GET", "/sessions", queryParams, nil, &retVal)
+	err := c.C.NewRequest(ctx, "GET", "/sessions", queryParams, nil, &retVal)
 	return &retVal, err
 }
 
@@ -38,7 +38,7 @@ func (c *Client) GetJWKS(
 	path := "/sessions/jwks/" + body.ProjectID
 
 	var retVal stytch.SessionsGetJWKSResponse
-	err := c.C.NewRequest("GET", path, nil, nil, &retVal)
+	err := c.C.NewRequest(ctx, "GET", path, nil, nil, &retVal)
 	return &retVal, err
 }
 
@@ -144,7 +144,7 @@ func (c *Client) Authenticate(
 	}
 
 	var retVal stytch.SessionsAuthenticateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -168,7 +168,7 @@ func (c *Client) AuthenticateWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}
@@ -209,6 +209,6 @@ func (c *Client) Revoke(
 	}
 
 	var retVal stytch.SessionsRevokeResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }

--- a/stytch/session/session_test.go
+++ b/stytch/session/session_test.go
@@ -1,6 +1,7 @@
 package session_test
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
@@ -191,7 +192,7 @@ func TestAuthenticateWithClaims(t *testing.T) {
 
 	t.Run("marshaling claims into a map", func(t *testing.T) {
 		var claims map[string]interface{}
-		_, err := client.Sessions.AuthenticateWithClaims(req, &claims)
+		_, err := client.Sessions.AuthenticateWithClaims(context.Background(), req, &claims)
 		require.NoError(t, err)
 
 		type object = map[string]interface{}
@@ -222,7 +223,7 @@ func TestAuthenticateWithClaims(t *testing.T) {
 
 		{
 			var claims Claims
-			_, err = client.Sessions.AuthenticateWithClaims(req, &claims)
+			_, err = client.Sessions.AuthenticateWithClaims(context.Background(), req, &claims)
 			require.NoError(t, err)
 			expected := Claims{
 				MyApp: MyAppClaims{
@@ -283,7 +284,7 @@ func ExampleClient_AuthenticateWithClaims_map() {
 
 	// Expecting a map where all the values are maps from strings to integers
 	var mapClaims map[string]map[string]int32
-	_, _ = client.Sessions.AuthenticateWithClaims(&stytch.SessionsAuthenticateParams{
+	_, _ = client.Sessions.AuthenticateWithClaims(context.Background(), &stytch.SessionsAuthenticateParams{
 		SessionToken: "fake session token",
 	}, &mapClaims)
 
@@ -350,7 +351,7 @@ func ExampleClient_AuthenticateWithClaims_struct() {
 	}
 
 	var structClaims StructClaims
-	_, _ = client.Sessions.AuthenticateWithClaims(&stytch.SessionsAuthenticateParams{
+	_, _ = client.Sessions.AuthenticateWithClaims(context.Background(), &stytch.SessionsAuthenticateParams{
 		SessionToken: "fake session token",
 	}, &structClaims)
 

--- a/stytch/session/session_test.go
+++ b/stytch/session/session_test.go
@@ -284,9 +284,13 @@ func ExampleClient_AuthenticateWithClaims_map() {
 
 	// Expecting a map where all the values are maps from strings to integers
 	var mapClaims map[string]map[string]int32
-	_, _ = client.Sessions.AuthenticateWithClaims(context.Background(), &stytch.SessionsAuthenticateParams{
-		SessionToken: "fake session token",
-	}, &mapClaims)
+	_, _ = client.Sessions.AuthenticateWithClaims(
+		context.Background(),
+		&stytch.SessionsAuthenticateParams{
+			SessionToken: "fake session token",
+		},
+		&mapClaims,
+	)
 
 	fmt.Println(mapClaims)
 	// Output: map[https://my-app.example.net/custom-claim:map[claim1:1 claim2:2 claim3:3]]
@@ -351,9 +355,13 @@ func ExampleClient_AuthenticateWithClaims_struct() {
 	}
 
 	var structClaims StructClaims
-	_, _ = client.Sessions.AuthenticateWithClaims(context.Background(), &stytch.SessionsAuthenticateParams{
-		SessionToken: "fake session token",
-	}, &structClaims)
+	_, _ = client.Sessions.AuthenticateWithClaims(
+		context.Background(),
+		&stytch.SessionsAuthenticateParams{
+			SessionToken: "fake session token",
+		},
+		&structClaims,
+	)
 
 	fmt.Println(structClaims)
 	// Output: {{1 [1 foo <nil>] {here}}}

--- a/stytch/stytch.go
+++ b/stytch/stytch.go
@@ -38,7 +38,11 @@ func New(env config.Env, projectID string, secret string) *Client {
 }
 
 // newRequest is used by Call to generate and Do a http.Request
-func (c *Client) NewRequest(ctx context.Context, method string, path string, queryParams map[string]string,
+func (c *Client) NewRequest(
+	ctx context.Context,
+	method string,
+	path string,
+	queryParams map[string]string,
 	body []byte, v interface{},
 ) error {
 	b, err := c.RawRequest(ctx, method, path, queryParams, body)

--- a/stytch/stytch.go
+++ b/stytch/stytch.go
@@ -2,6 +2,7 @@ package stytch
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -37,10 +38,10 @@ func New(env config.Env, projectID string, secret string) *Client {
 }
 
 // newRequest is used by Call to generate and Do a http.Request
-func (c *Client) NewRequest(method string, path string, queryParams map[string]string,
+func (c *Client) NewRequest(ctx context.Context, method string, path string, queryParams map[string]string,
 	body []byte, v interface{},
 ) error {
-	b, err := c.RawRequest(method, path, queryParams, body)
+	b, err := c.RawRequest(ctx, method, path, queryParams, body)
 	if err != nil {
 		return err
 	}
@@ -56,6 +57,7 @@ func (c *Client) NewRequest(method string, path string, queryParams map[string]s
 //
 // Prefer using NewRequest (which unmarshals the response JSON) unless you need the actual bytes.
 func (c *Client) RawRequest(
+	ctx context.Context,
 	method string,
 	path string,
 	queryParams map[string]string,
@@ -67,7 +69,7 @@ func (c *Client) RawRequest(
 
 	path = string(c.Config.BaseURI) + path
 
-	req, err := http.NewRequest(method, path, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, method, path, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("error creating http request: %w", err)
 	}

--- a/stytch/stytchapi/stytchapi_test.go
+++ b/stytch/stytchapi/stytchapi_test.go
@@ -1,6 +1,7 @@
 package stytchapi_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -56,9 +57,12 @@ func TestNewClient(t *testing.T) {
 		)
 		assert.NoError(t, err)
 
-		_, err = client.MagicLinks.Authenticate(&stytch.MagicLinksAuthenticateParams{
-			Token: "fake-token",
-		})
+		_, err = client.MagicLinks.Authenticate(
+			context.Background(),
+			&stytch.MagicLinksAuthenticateParams{
+				Token: "fake-token",
+			},
+		)
 		assert.NoError(t, err)
 	})
 }

--- a/stytch/totp/totp.go
+++ b/stytch/totp/totp.go
@@ -29,7 +29,7 @@ func (c *Client) Create(body *stytch.TOTPsCreateParams) (
 	}
 
 	var retVal stytch.TOTPsCreateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -50,7 +50,7 @@ func (c *Client) Authenticate(body *stytch.TOTPsAuthenticateParams) (
 	}
 
 	var retVal stytch.TOTPsAuthenticateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -75,7 +75,7 @@ func (c *Client) AuthenticateWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (c *Client) RecoveryCodes(body *stytch.TOTPsRecoveryCodesParams) (
 	}
 
 	var retVal stytch.TOTPsRecoveryCodesResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -140,7 +140,7 @@ func (c *Client) Recover(body *stytch.TOTPsRecoverParams) (
 	}
 
 	var retVal stytch.TOTPsRecoverResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -165,7 +165,7 @@ func (c *Client) RecoverWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}

--- a/stytch/totp/totp.go
+++ b/stytch/totp/totp.go
@@ -1,6 +1,7 @@
 package totp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -12,7 +13,7 @@ type Client struct {
 	C *stytch.Client
 }
 
-func (c *Client) Create(body *stytch.TOTPsCreateParams) (
+func (c *Client) Create(ctx context.Context, body *stytch.TOTPsCreateParams) (
 	*stytch.TOTPsCreateResponse, error,
 ) {
 	path := "/totps"
@@ -33,7 +34,7 @@ func (c *Client) Create(body *stytch.TOTPsCreateParams) (
 	return &retVal, err
 }
 
-func (c *Client) Authenticate(body *stytch.TOTPsAuthenticateParams) (
+func (c *Client) Authenticate(ctx context.Context, body *stytch.TOTPsAuthenticateParams) (
 	*stytch.TOTPsAuthenticateResponse, error,
 ) {
 	path := "/totps/authenticate"
@@ -59,6 +60,7 @@ func (c *Client) Authenticate(body *stytch.TOTPsAuthenticateParams) (
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
+	ctx context.Context,
 	body *stytch.TOTPsAuthenticateParams,
 	claims interface{},
 ) (*stytch.TOTPsAuthenticateResponse, error) {
@@ -102,7 +104,7 @@ func (c *Client) AuthenticateWithClaims(
 	return &retVal, err
 }
 
-func (c *Client) RecoveryCodes(body *stytch.TOTPsRecoveryCodesParams) (
+func (c *Client) RecoveryCodes(ctx context.Context, body *stytch.TOTPsRecoveryCodesParams) (
 	*stytch.TOTPsRecoveryCodesResponse, error,
 ) {
 	path := "/totps/recovery_codes"
@@ -123,7 +125,7 @@ func (c *Client) RecoveryCodes(body *stytch.TOTPsRecoveryCodesParams) (
 	return &retVal, err
 }
 
-func (c *Client) Recover(body *stytch.TOTPsRecoverParams) (
+func (c *Client) Recover(ctx context.Context, body *stytch.TOTPsRecoverParams) (
 	*stytch.TOTPsRecoverResponse, error,
 ) {
 	path := "/totps/recover"
@@ -149,6 +151,7 @@ func (c *Client) Recover(body *stytch.TOTPsRecoverParams) (
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) RecoverWithClaims(
+	ctx context.Context,
 	body *stytch.TOTPsRecoverParams,
 	claims interface{},
 ) (*stytch.TOTPsRecoverResponse, error) {

--- a/stytch/user/user.go
+++ b/stytch/user/user.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 
@@ -12,7 +13,7 @@ type Client struct {
 	C *stytch.Client
 }
 
-func (c *Client) Create(body *stytch.UsersCreateParams) (*stytch.UsersCreateResponse, error) {
+func (c *Client) Create(ctx context.Context, body *stytch.UsersCreateParams) (*stytch.UsersCreateResponse, error) {
 	var jsonBody []byte
 	var err error
 	if body != nil {
@@ -28,7 +29,7 @@ func (c *Client) Create(body *stytch.UsersCreateParams) (*stytch.UsersCreateResp
 	return &retVal, err
 }
 
-func (c *Client) Get(userID string) (*stytch.UsersGetResponse, error) {
+func (c *Client) Get(ctx context.Context, userID string) (*stytch.UsersGetResponse, error) {
 	path := "/users/" + userID
 
 	var retVal stytch.UsersGetResponse
@@ -37,6 +38,7 @@ func (c *Client) Get(userID string) (*stytch.UsersGetResponse, error) {
 }
 
 func (c *Client) GetPending(
+	ctx context.Context,
 	body *stytch.UsersGetPendingParams,
 ) (*stytch.UsersGetPendingResponse, error) {
 	var queryParams map[string]string
@@ -58,6 +60,7 @@ func (c *Client) GetPending(
 }
 
 func (c *Client) Search(
+	ctx context.Context,
 	body *stytch.UsersSearchParams,
 ) (*stytch.UsersSearchResponse, error) {
 	var jsonBody []byte
@@ -94,8 +97,8 @@ func (i *UserSearchIterator) HasNext() bool {
 	return i.state == iteratorStatePending || i.state == iteratorStateInProgress
 }
 
-func (i *UserSearchIterator) Next() ([]stytch.User, error) {
-	res, err := i.c.Search(i.body)
+func (i *UserSearchIterator) Next(ctx context.Context) ([]stytch.User, error) {
+	res, err := i.c.Search(ctx, i.body)
 	if err != nil {
 		i.state = iteratorStateErrored
 		return nil, err
@@ -118,7 +121,9 @@ func (c *Client) SearchAll(body *stytch.UsersSearchParams) *UserSearchIterator {
 }
 
 func (c *Client) Update(
-	userID string, body *stytch.UsersUpdateParams,
+	ctx context.Context,
+	userID string,
+	body *stytch.UsersUpdateParams,
 ) (*stytch.UsersUpdateResponse, error) {
 	path := "/users/" + userID
 
@@ -137,7 +142,7 @@ func (c *Client) Update(
 	return &retVal, err
 }
 
-func (c *Client) Delete(userID string) (*stytch.UsersDeleteResponse, error) {
+func (c *Client) Delete(ctx context.Context, userID string) (*stytch.UsersDeleteResponse, error) {
 	path := "/users/" + userID
 
 	var retVal stytch.UsersDeleteResponse
@@ -145,7 +150,7 @@ func (c *Client) Delete(userID string) (*stytch.UsersDeleteResponse, error) {
 	return &retVal, err
 }
 
-func (c *Client) DeleteEmail(emailID string) (*stytch.UsersDeleteEmailResponse, error) {
+func (c *Client) DeleteEmail(ctx context.Context, emailID string) (*stytch.UsersDeleteEmailResponse, error) {
 	path := "/users/emails/" + emailID
 
 	var retVal stytch.UsersDeleteEmailResponse
@@ -154,6 +159,7 @@ func (c *Client) DeleteEmail(emailID string) (*stytch.UsersDeleteEmailResponse, 
 }
 
 func (c *Client) DeletePhoneNumber(
+	ctx context.Context,
 	phoneID string,
 ) (*stytch.UsersDeletePhoneNumberResponse, error) {
 	path := "/users/phone_numbers/" + phoneID
@@ -164,6 +170,7 @@ func (c *Client) DeletePhoneNumber(
 }
 
 func (c *Client) DeleteWebAuthnRegistration(
+	ctx context.Context,
 	webAuthnRegistration string,
 ) (*stytch.UsersDeleteWebAuthnRegistrationResponse, error) {
 	path := "/users/webauthn_registrations/" + webAuthnRegistration
@@ -174,6 +181,7 @@ func (c *Client) DeleteWebAuthnRegistration(
 }
 
 func (c *Client) DeleteBiometricRegistration(
+	ctx context.Context,
 	biometricRegistrationID string,
 ) (*stytch.UsersDeleteBiometricRegistrationResponse, error) {
 	path := "/users/biometric_registrations/" + biometricRegistrationID
@@ -184,6 +192,7 @@ func (c *Client) DeleteBiometricRegistration(
 }
 
 func (c *Client) DeleteTOTP(
+	ctx context.Context,
 	totpID string,
 ) (*stytch.UsersDeleteTOTPResponse, error) {
 	path := "/users/totps/" + totpID
@@ -194,6 +203,7 @@ func (c *Client) DeleteTOTP(
 }
 
 func (c *Client) DeleteCryptoWallet(
+	ctx context.Context,
 	cryptoWalletID string,
 ) (*stytch.UsersDeleteCryptoWalletResponse, error) {
 	path := "/users/crypto_wallets/" + cryptoWalletID
@@ -204,6 +214,7 @@ func (c *Client) DeleteCryptoWallet(
 }
 
 func (c *Client) DeletePassword(
+	ctx context.Context,
 	passwordID string,
 ) (*stytch.UsersDeletePasswordResponse, error) {
 	path := "/users/passwords/" + passwordID
@@ -214,6 +225,7 @@ func (c *Client) DeletePassword(
 }
 
 func (c *Client) DeleteOAuthUserRegistration(
+	ctx context.Context,
 	oauthUserRegistrationID string,
 ) (*stytch.UsersDeleteOAuthRegistrationResponse, error) {
 	path := "/users/oauth/" + oauthUserRegistrationID

--- a/stytch/user/user.go
+++ b/stytch/user/user.go
@@ -13,7 +13,10 @@ type Client struct {
 	C *stytch.Client
 }
 
-func (c *Client) Create(ctx context.Context, body *stytch.UsersCreateParams) (*stytch.UsersCreateResponse, error) {
+func (c *Client) Create(
+	ctx context.Context,
+	body *stytch.UsersCreateParams,
+) (*stytch.UsersCreateResponse, error) {
 	var jsonBody []byte
 	var err error
 	if body != nil {
@@ -29,7 +32,10 @@ func (c *Client) Create(ctx context.Context, body *stytch.UsersCreateParams) (*s
 	return &retVal, err
 }
 
-func (c *Client) Get(ctx context.Context, userID string) (*stytch.UsersGetResponse, error) {
+func (c *Client) Get(
+	ctx context.Context,
+	userID string,
+) (*stytch.UsersGetResponse, error) {
 	path := "/users/" + userID
 
 	var retVal stytch.UsersGetResponse
@@ -142,7 +148,10 @@ func (c *Client) Update(
 	return &retVal, err
 }
 
-func (c *Client) Delete(ctx context.Context, userID string) (*stytch.UsersDeleteResponse, error) {
+func (c *Client) Delete(
+	ctx context.Context,
+	userID string,
+) (*stytch.UsersDeleteResponse, error) {
 	path := "/users/" + userID
 
 	var retVal stytch.UsersDeleteResponse
@@ -150,7 +159,10 @@ func (c *Client) Delete(ctx context.Context, userID string) (*stytch.UsersDelete
 	return &retVal, err
 }
 
-func (c *Client) DeleteEmail(ctx context.Context, emailID string) (*stytch.UsersDeleteEmailResponse, error) {
+func (c *Client) DeleteEmail(
+	ctx context.Context,
+	emailID string,
+) (*stytch.UsersDeleteEmailResponse, error) {
 	path := "/users/emails/" + emailID
 
 	var retVal stytch.UsersDeleteEmailResponse

--- a/stytch/user/user.go
+++ b/stytch/user/user.go
@@ -24,7 +24,7 @@ func (c *Client) Create(body *stytch.UsersCreateParams) (*stytch.UsersCreateResp
 	}
 
 	var retVal stytch.UsersCreateResponse
-	err = c.C.NewRequest("POST", "/users", nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", "/users", nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -32,7 +32,7 @@ func (c *Client) Get(userID string) (*stytch.UsersGetResponse, error) {
 	path := "/users/" + userID
 
 	var retVal stytch.UsersGetResponse
-	err := c.C.NewRequest("GET", path, nil, nil, &retVal)
+	err := c.C.NewRequest(ctx, "GET", path, nil, nil, &retVal)
 	return &retVal, err
 }
 
@@ -53,7 +53,7 @@ func (c *Client) GetPending(
 	}
 
 	var retVal stytch.UsersGetPendingResponse
-	err := c.C.NewRequest("GET", "/users/pending", queryParams, nil, &retVal)
+	err := c.C.NewRequest(ctx, "GET", "/users/pending", queryParams, nil, &retVal)
 	return &retVal, err
 }
 
@@ -71,7 +71,7 @@ func (c *Client) Search(
 	}
 
 	var retVal stytch.UsersSearchResponse
-	err = c.C.NewRequest("POST", "/users/search", nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", "/users/search", nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -133,7 +133,7 @@ func (c *Client) Update(
 	}
 
 	var retVal stytch.UsersUpdateResponse
-	err = c.C.NewRequest("PUT", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "PUT", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -141,7 +141,7 @@ func (c *Client) Delete(userID string) (*stytch.UsersDeleteResponse, error) {
 	path := "/users/" + userID
 
 	var retVal stytch.UsersDeleteResponse
-	err := c.C.NewRequest("DELETE", path, nil, nil, &retVal)
+	err := c.C.NewRequest(ctx, "DELETE", path, nil, nil, &retVal)
 	return &retVal, err
 }
 
@@ -149,7 +149,7 @@ func (c *Client) DeleteEmail(emailID string) (*stytch.UsersDeleteEmailResponse, 
 	path := "/users/emails/" + emailID
 
 	var retVal stytch.UsersDeleteEmailResponse
-	err := c.C.NewRequest("DELETE", path, nil, nil, &retVal)
+	err := c.C.NewRequest(ctx, "DELETE", path, nil, nil, &retVal)
 	return &retVal, err
 }
 
@@ -159,7 +159,7 @@ func (c *Client) DeletePhoneNumber(
 	path := "/users/phone_numbers/" + phoneID
 
 	var retVal stytch.UsersDeletePhoneNumberResponse
-	err := c.C.NewRequest("DELETE", path, nil, nil, &retVal)
+	err := c.C.NewRequest(ctx, "DELETE", path, nil, nil, &retVal)
 	return &retVal, err
 }
 
@@ -169,7 +169,7 @@ func (c *Client) DeleteWebAuthnRegistration(
 	path := "/users/webauthn_registrations/" + webAuthnRegistration
 
 	var retVal stytch.UsersDeleteWebAuthnRegistrationResponse
-	err := c.C.NewRequest("DELETE", path, nil, nil, &retVal)
+	err := c.C.NewRequest(ctx, "DELETE", path, nil, nil, &retVal)
 	return &retVal, err
 }
 
@@ -179,7 +179,7 @@ func (c *Client) DeleteBiometricRegistration(
 	path := "/users/biometric_registrations/" + biometricRegistrationID
 
 	var retVal stytch.UsersDeleteBiometricRegistrationResponse
-	err := c.C.NewRequest("DELETE", path, nil, nil, &retVal)
+	err := c.C.NewRequest(ctx, "DELETE", path, nil, nil, &retVal)
 	return &retVal, err
 }
 
@@ -189,7 +189,7 @@ func (c *Client) DeleteTOTP(
 	path := "/users/totps/" + totpID
 
 	var retVal stytch.UsersDeleteTOTPResponse
-	err := c.C.NewRequest("DELETE", path, nil, nil, &retVal)
+	err := c.C.NewRequest(ctx, "DELETE", path, nil, nil, &retVal)
 	return &retVal, err
 }
 
@@ -199,7 +199,7 @@ func (c *Client) DeleteCryptoWallet(
 	path := "/users/crypto_wallets/" + cryptoWalletID
 
 	var retVal stytch.UsersDeleteCryptoWalletResponse
-	err := c.C.NewRequest("DELETE", path, nil, nil, &retVal)
+	err := c.C.NewRequest(ctx, "DELETE", path, nil, nil, &retVal)
 	return &retVal, err
 }
 
@@ -209,7 +209,7 @@ func (c *Client) DeletePassword(
 	path := "/users/passwords/" + passwordID
 
 	var retVal stytch.UsersDeletePasswordResponse
-	err := c.C.NewRequest("DELETE", path, nil, nil, &retVal)
+	err := c.C.NewRequest(ctx, "DELETE", path, nil, nil, &retVal)
 	return &retVal, err
 }
 
@@ -219,6 +219,6 @@ func (c *Client) DeleteOAuthUserRegistration(
 	path := "/users/oauth/" + oauthUserRegistrationID
 
 	var retVal stytch.UsersDeleteOAuthRegistrationResponse
-	err := c.C.NewRequest("DELETE", path, nil, nil, &retVal)
+	err := c.C.NewRequest(ctx, "DELETE", path, nil, nil, &retVal)
 	return &retVal, err
 }

--- a/stytch/webauthn/webauthn.go
+++ b/stytch/webauthn/webauthn.go
@@ -27,7 +27,7 @@ func (c *Client) RegisterStart(body *stytch.WebAuthnRegisterStartParams,
 	}
 
 	var retVal stytch.WebAuthnRegisterStartResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -46,7 +46,7 @@ func (c *Client) Register(body *stytch.WebAuthnRegisterParams,
 	}
 
 	var retVal stytch.WebAuthnRegisterResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -65,7 +65,7 @@ func (c *Client) AuthenticateStart(body *stytch.WebAuthnAuthenticateStartParams,
 	}
 
 	var retVal stytch.WebAuthnAuthenticateStartResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -84,7 +84,7 @@ func (c *Client) Authenticate(body *stytch.WebAuthnAuthenticateParams,
 	}
 
 	var retVal stytch.WebAuthnAuthenticateResponse
-	err = c.C.NewRequest("POST", path, nil, jsonBody, &retVal)
+	err = c.C.NewRequest(ctx, "POST", path, nil, jsonBody, &retVal)
 	return &retVal, err
 }
 
@@ -108,7 +108,7 @@ func (c *Client) AuthenticateWithClaims(
 		}
 	}
 
-	b, err := c.C.RawRequest("POST", path, nil, jsonBody)
+	b, err := c.C.RawRequest(ctx, "POST", path, nil, jsonBody)
 	if err != nil {
 		return nil, err
 	}

--- a/stytch/webauthn/webauthn.go
+++ b/stytch/webauthn/webauthn.go
@@ -1,6 +1,7 @@
 package webauthn
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -12,7 +13,9 @@ type Client struct {
 	C *stytch.Client
 }
 
-func (c *Client) RegisterStart(body *stytch.WebAuthnRegisterStartParams,
+func (c *Client) RegisterStart(
+	ctx context.Context,
+	body *stytch.WebAuthnRegisterStartParams,
 ) (*stytch.WebAuthnRegisterStartResponse, error) {
 	path := "/webauthn/register/start"
 
@@ -31,7 +34,9 @@ func (c *Client) RegisterStart(body *stytch.WebAuthnRegisterStartParams,
 	return &retVal, err
 }
 
-func (c *Client) Register(body *stytch.WebAuthnRegisterParams,
+func (c *Client) Register(
+	ctx context.Context,
+	body *stytch.WebAuthnRegisterParams,
 ) (*stytch.WebAuthnRegisterResponse, error) {
 	path := "/webauthn/register"
 
@@ -50,7 +55,9 @@ func (c *Client) Register(body *stytch.WebAuthnRegisterParams,
 	return &retVal, err
 }
 
-func (c *Client) AuthenticateStart(body *stytch.WebAuthnAuthenticateStartParams,
+func (c *Client) AuthenticateStart(
+	ctx context.Context,
+	body *stytch.WebAuthnAuthenticateStartParams,
 ) (*stytch.WebAuthnAuthenticateStartResponse, error) {
 	path := "/webauthn/authenticate/start"
 
@@ -69,7 +76,9 @@ func (c *Client) AuthenticateStart(body *stytch.WebAuthnAuthenticateStartParams,
 	return &retVal, err
 }
 
-func (c *Client) Authenticate(body *stytch.WebAuthnAuthenticateParams,
+func (c *Client) Authenticate(
+	ctx context.Context,
+	body *stytch.WebAuthnAuthenticateParams,
 ) (*stytch.WebAuthnAuthenticateResponse, error) {
 	path := "/webauthn/authenticate"
 
@@ -93,6 +102,7 @@ func (c *Client) Authenticate(body *stytch.WebAuthnAuthenticateParams,
 // the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
 // ExampleClient_AuthenticateWithClaims_struct for examples
 func (c *Client) AuthenticateWithClaims(
+	ctx context.Context,
 	body *stytch.WebAuthnAuthenticateParams,
 	claims interface{},
 ) (*stytch.WebAuthnAuthenticateResponse, error) {


### PR DESCRIPTION
As per #95 , it would be helpful to pass a context.Context() in API calls that is threaded to the http routes.

this adds it as the first parameter in each method, as is the go style.

Do we want to completely migrate to versions with context, or continue to offer the non contextual versions?

e.g., we could instead define

```
func (c *Client) Authenticate(body *stytch.CryptoWalletAuthenticateParams)
```
and

```
func (c *Client) AuthenticateWithContext(ctx context.Context, body *stytch.CryptoWalletAuthenticateParams)
```