### PR TITLE
doc: Mark Users.GetPending as deprecated

### DIFF
--- a/stytch/b2c/user/user.go
+++ b/stytch/b2c/user/user.go
@@ -45,6 +45,7 @@ func (c *Client) Get(
 	return &retVal, err
 }
 
+// Deprecated: Use Search or SearchAll with UsersSearchQueryStatusFilter{Status: "pending"} instead.
 func (c *Client) GetPending(
 	ctx context.Context,
 	body *b2c.UsersGetPendingParams,

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "8.0.0"
+const APIVersion = "8.1.0"
 
 type BaseURI string
 


### PR DESCRIPTION
With the Users Search endpoint, you can get all of your pending users by adding a `Status: "pending"` filter. This can replace any and all existing calls to the Get Pending Users endpoint.

The Search method also supports more filters to further constrain results. This library also provides a SearchAll convenience helper for iterating through all the results of a search.

We'd like to remove the GetPending method from this library to limit our maintenance work and remove some complexity for customers.

This marks the GetPending method as deprecated. It will be removed in the next major version of stytch-go.

## Migration Guide

This migrates from GetPending to SearchAll, which has a cleaner iteration pattern:

**Before**

```go
ctx := context.TODO()

params := &b2c.UsersGetPendingParams{
    Limit: 200,
}

res, err := client.Users.GetPending(ctx, params)
if err != nil {
	panic(err)
}

// TODO: Do something with res.Users

for res.HasMore {
	params.StartingAfterID = res.StartingAfterID

	res, err = client.Users.GetPending(ctx, params)
	if err != nil {
		panic(err)
	}

	// TODO: Do something with res.Users
}
```

**After**

```go
ctx := context.TODO()

params := &b2c.UsersSearchParams{
    Limit: 200,
	Query: &b2c.UsersSearchQuery{
		Operator: b2c.UserSearchOperatorOR,
		Operands: []json.Marshaler{
			b2c.UsersSearchQueryStatusFilter{Status: "pending"},
		},
	},
}

pendingUsers := client.Users.SearchAll(params)

for pendingUsers.HasNext() {
	users, err := pendingUsers.Next(ctx)
	if err != nil {
		panic(err)
	}

	// TODO: Do something with users
}
```

If you prefer to keep the same iteration pattern that GetPending has, use Search directly instead:

```go
ctx := context.TODO()

params := &b2c.UsersSearchParams{
    Limit: 200,
	Query: &b2c.UsersSearchQuery{
		Operator: b2c.UserSearchOperatorOR,
		Operands: []json.Marshaler{
			b2c.UsersSearchQueryStatusFilter{Status: "pending"},
		},
	},
}

res, err := client.Users.Search(ctx, params)
if err != nil {
	panic(err)
}

// TODO: Do something with res.Results

for res.ResultsMetadata.NextCursor != "" {
	params.Cursor = res.ResultsMetadata.NextCursor

	res, err = client.Users.Search(ctx, params)
	if err != nil {
		panic(err)
	}

	// TODO: Do something with res.Results
}
```