### PR TITLE
Add client setup options for init Context and HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ This client library supports all of Stytch's live products:
 Create an API client:
 ```go
 import (
-	"os"
+	"context"
 
 	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytchapi"
+	"github.com/stytchauth/stytch-go/v8/stytch/b2c/stytchapi"
 )
 
 stytchAPIClient, err := stytchapi.NewAPIClient(
@@ -53,12 +53,12 @@ Send a magic link by email:
 	res, err := stytchAPIClient.MagicLinks.Email.Send(
 		context.Background(),
 		&stytch.MagicLinksEmailSendParams{
-		    Email:              "sandbox@stytch.com",
-		    Attributes:         stytch.Attributes{
-			    IPAddress: "10.0.0.0",
-		    },
-        },
-    )
+			Email: "sandbox@stytch.com",
+			Attributes: stytch.Attributes{
+				IPAddress: "10.0.0.0",
+			},
+		},
+	)
 ```
 
 Authenticate the token from the magic link:
@@ -77,7 +77,7 @@ Get all users
     res, err := stytchAPIClient.Users.Search(
 		context.Background(),
 		&stytch.UsersSearchParams{
-			Limit: 1000	
+			Limit: 1000
 		})
 ```
 
@@ -93,12 +93,12 @@ Search users
 					stytch.UsersSearchQueryPhoneVerifiedFilter{true},
 					stytch.UsersSearchQueryEmailVerifiedFilter{true},
 					stytch.UsersSearchQueryWebAuthnRegistrationVerifiedFilter{true},
-				}           
+				}
 			}
 		})
 ```
 
-Iterate over all pages of users for a search query 
+Iterate over all pages of users for a search query
 ```go
 	var users []stytch.User
 	iter := stytchAPIClient.Users.SearchAll(&stytch.UsersSearchParams{})

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/stytchauth/stytch-go/v8
 go 1.18
 
 require (
-	github.com/MicahParks/keyfunc v1.0.1
-	github.com/golang-jwt/jwt/v4 v4.4.0
+	github.com/MicahParks/keyfunc/v2 v2.0.1
+	github.com/golang-jwt/jwt/v5 v5.0.0
 	github.com/stretchr/testify v1.8.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,10 @@
-github.com/MicahParks/keyfunc v1.0.1 h1:BIKfiyELXV0A8SRCHQaByJW0s71xXpArhzfTS3uf26c=
-github.com/MicahParks/keyfunc v1.0.1/go.mod h1:R8RZa27qn+5cHTfYLJ9/+7aSb5JIdz7cl0XFo0o4muo=
+github.com/MicahParks/keyfunc/v2 v2.0.1 h1:6FrNNvG/20gEKkjxV+5anrkq0VOF666G2zUn8lk8dgk=
+github.com/MicahParks/keyfunc/v2 v2.0.1/go.mod h1:rW42fi+xgLJ2FRRXAfNx9ZA8WpD4OeE/yHVMteCkw9k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
-github.com/golang-jwt/jwt/v4 v4.4.0 h1:EmVIxB5jzbllGIjiCV5JG4VylbK3KE400tLGLI1cdfU=
-github.com/golang-jwt/jwt/v4 v4.4.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/stytch/b2c/attributes.go
+++ b/stytch/b2c/attributes.go
@@ -1,6 +1,6 @@
 package b2c
 
-import "github.com/golang-jwt/jwt/v4"
+import "github.com/golang-jwt/jwt/v5"
 
 /*
  * Structure for the custom type Attributes

--- a/stytch/b2c/stytchapi/stytchapi.go
+++ b/stytch/b2c/stytchapi/stytchapi.go
@@ -3,6 +3,7 @@ package stytchapi
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/stytchauth/stytch-go/v8/stytch/b2c/cryptowallet"
@@ -49,6 +50,12 @@ type Option func(*API)
 
 func WithLogger(logger Logger) Option {
 	return func(api *API) { api.logger = logger }
+}
+
+// WithHTTPClient overrides the HTTP client used by the API client. The default value is
+// &http.Client{}.
+func WithHTTPClient(client *http.Client) Option {
+	return func(api *API) { api.client.HTTPClient = client }
 }
 
 // WithBaseURI overrides the client base URI determined by the environment.

--- a/stytch/b2c/stytchapi/stytchapi.go
+++ b/stytch/b2c/stytchapi/stytchapi.go
@@ -115,7 +115,9 @@ func (a *API) instantiateJWKSClient(client *stytch.Client) (*keyfunc.JWKS, error
 		RefreshTimeout:    10 * time.Second,
 		RefreshUnknownKID: true,
 	}
-	jwkURL := string(client.Config.GetBaseURI()) +
-		fmt.Sprintf("/sessions/jwks/%s", client.Config.BasicAuthProjectID())
-	return keyfunc.Get(jwkURL, jwkOptions)
+
+	baseURI := client.Config.GetBaseURI()
+	projectID := client.Config.BasicAuthProjectID()
+	jwksURL := fmt.Sprintf("%s/sessions/jwks/%s", baseURI, projectID)
+	return keyfunc.Get(jwksURL, jwkOptions)
 }

--- a/stytch/b2c/stytchapi/stytchapi.go
+++ b/stytch/b2c/stytchapi/stytchapi.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stytchauth/stytch-go/v8/stytch/b2c/user"
 	"github.com/stytchauth/stytch-go/v8/stytch/b2c/webauthn"
 
-	"github.com/MicahParks/keyfunc"
+	"github.com/MicahParks/keyfunc/v2"
 	"github.com/stytchauth/stytch-go/v8/stytch"
 	"github.com/stytchauth/stytch-go/v8/stytch/config"
 )

--- a/stytch/b2c/stytchapi/stytchapi_test.go
+++ b/stytch/b2c/stytchapi/stytchapi_test.go
@@ -16,33 +16,15 @@ import (
 )
 
 func TestNewClient(t *testing.T) {
-	t.Run("live environment", func(t *testing.T) {
-		_, err := stytchapi.NewAPIClient(
-			stytch.EnvLive,
-			"project-live-00000000-0000-0000-0000-000000000000",
-			"secret-live-11111111-1111-1111-1111-111111111111",
-		)
-		assert.NoError(t, err)
-	})
-
-	t.Run("test environment", func(t *testing.T) {
-		_, err := stytchapi.NewAPIClient(
-			stytch.EnvTest,
-			"project-test-00000000-0000-0000-0000-000000000000",
-			"secret-test-11111111-1111-1111-1111-111111111111",
-		)
-		assert.NoError(t, err)
-	})
-
 	t.Run("internal development override", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Handle the async JWKS fetch
+			// Handle the JWKS fetch that happens during setup.
 			if strings.HasPrefix(r.URL.Path, "/sessions/jwks/") {
 				_, _ = w.Write([]byte(`{"keys": []}`))
 				return
 			}
 
-			// This is the test request
+			// This is the test request.
 			if r.URL.Path == "/magic_links/authenticate" {
 				_, _ = w.Write([]byte(`{}`))
 				return

--- a/stytch/b2c/stytchapi/stytchapi_test.go
+++ b/stytch/b2c/stytchapi/stytchapi_test.go
@@ -97,6 +97,38 @@ func TestNewClient(t *testing.T) {
 			assert.Equal(t, stytcherror.Message("I'm a teapot!"), stytchErr.ErrorMessage)
 		}
 	})
+
+	t.Run("JWKS URL", func(t *testing.T) {
+		httpClient := &http.Client{
+			Transport: RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				// Make sure the path got built correctly.
+				if assert.Equal(t, "/v1/sessions/jwks/project-test-00000000-0000-0000-0000-000000000000", r.URL.Path) {
+					resp := &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(strings.NewReader(`{"keys": []}`)),
+					}
+					return resp, nil
+				}
+
+				// And then fail it anyway so this doesn't hit the real internet.
+				resp := &http.Response{
+					StatusCode: http.StatusTeapot,
+					Body: io.NopCloser(strings.NewReader(
+						`{"status_code": 418, "error_type": "teapot", "error_message": "I'm a teapot!"}`,
+					)),
+				}
+				return resp, nil
+			}),
+		}
+
+		_, err := stytchapi.NewAPIClient(
+			stytch.EnvTest,
+			"project-test-00000000-0000-0000-0000-000000000000",
+			"secret-test-11111111-1111-1111-1111-111111111111",
+			stytchapi.WithHTTPClient(httpClient),
+		)
+		require.NoError(t, err)
+	})
 }
 
 type RoundTripperFunc func(*http.Request) (*http.Response, error)

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "8.1.0"
+const APIVersion = "8.2.0"
 
 type BaseURI string
 


### PR DESCRIPTION
This PR contains two changes related to API client startup. In order of importance:

1. Accept an init context to use when starting the API client. This allows canceling client creation if the initial JWKS fetch takes too long.

   The easiest way to get this done was to upgrade through keyfunc v2.0.1 (which has a context bugfix). This is something nice to do anyway.

   This option is different from our other `stytchapi.Option` arguments because it doesn't change the underlying `API` client in any way. So the init context can't easily be set as one of the variadic option args. Instead, there's a new client constructor that takes the context as the first argument.

2. Add an HTTP client override option. This is useful for anyone who needs to override the HTTP client to change things like the transport settings.

   This one _can_ be done as one of the variadic option args, so we don't have to do anything special for it.

## Migration Guide

If you need to control the setup context for the Stytch API client, use `NewAPIClientWithContext` instead of `NewAPIClient`. You can keep same behavior by passing `context.Background()` as the context, which will allow unlimited time for client creation.

## Reviewer Notes

I intend to rebase-merge the commits in this PR, which is unusual for this repo. Please review the individual commits.

This is the same as #121 except that the init context changes are done in a non-breaking way. So this does not contain any of the add-on major-version changes.