### PR TITLE
Add NewClient which infers environment from projectID

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ import (
 	"github.com/stytchauth/stytch-go/v8/stytch/b2c/stytchapi"
 )
 
-stytchAPIClient, err := stytchapi.NewAPIClient(
-	stytch.EnvTest, // available environments are EnvTest and EnvLive
+stytchAPIClient, err := stytchapi.NewClient(
 	"project-live-c60c0abe-c25a-4472-a9ed-320c6667d317",
 	"secret-live-80JASucyk7z_G8Z-7dVwZVGXL5NT_qGAQ2I=",
 )

--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -65,6 +65,10 @@ func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
 	return NewAPIClient(detectedEnv, projectID, secret, opts...)
 }
 
+// NewAPIClient returns a Stytch API client that uses the provided credentials.
+//
+// It is highly recommended to use NewClient instead of this function since it will automatically detect the correct
+// Stytch environment from the provided projectID. This function will be deprecated in a future MAJOR release.
 func NewAPIClient(env config.Env, projectID string, secret string, opts ...Option) (*API, error) {
 	a := &API{
 		client: stytch.New(env, projectID, secret),

--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -67,8 +67,9 @@ func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
 
 // NewAPIClient returns a Stytch API client that uses the provided credentials.
 //
-// It is highly recommended to use NewClient instead of this function since it will automatically detect the correct
-// Stytch environment from the provided projectID. This function will be deprecated in a future MAJOR release.
+// Deprecated: This method requires explicitly supplying a config.Env instead of detecting it automatically, which can
+// lead to bugs when the env does not match what's expected from the given projectID. Use NewClient instead and supply a
+// WithBaseURI if you need to explicitly override the client's BaseURI (typically only done for internal development).
 func NewAPIClient(env config.Env, projectID string, secret string, opts ...Option) (*API, error) {
 	a := &API{
 		client: stytch.New(env, projectID, secret),

--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -1,6 +1,8 @@
 package b2bstytchapi
 
 import (
+	"strings"
+
 	"github.com/stytchauth/stytch-go/v8/stytch"
 	"github.com/stytchauth/stytch-go/v8/stytch/b2b/discovery"
 	"github.com/stytchauth/stytch-go/v8/stytch/b2b/magiclink"
@@ -45,6 +47,22 @@ func WithLogger(logger Logger) Option {
 // this client to access internal development versions of the API.
 func WithBaseURI(uri string) Option {
 	return func(api *API) { api.client.Config.BaseURI = config.BaseURI(uri) }
+}
+
+// NewClient returns a Stytch API client that uses the provided credentials.
+//
+// It detects the environment from the given projectID. You are still free to pass WithBaseURI as an option if you wish
+// to override this behavior, but the intention is to provide a simpler interface for creating a client since it's
+// extremely rare that developers would want to use something other than the detected environment.
+func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
+	var detectedEnv config.Env
+	if strings.HasPrefix(projectID, "project-live-") {
+		detectedEnv = config.EnvLive
+	} else {
+		detectedEnv = config.EnvTest
+	}
+
+	return NewAPIClient(detectedEnv, projectID, secret, opts...)
 }
 
 func NewAPIClient(env config.Env, projectID string, secret string, opts ...Option) (*API, error) {

--- a/stytch/b2c/session/session_test.go
+++ b/stytch/b2c/session/session_test.go
@@ -208,8 +208,7 @@ func TestAuthenticateWithClaims(t *testing.T) {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 	}))
 
-	client, err := stytchapi.NewAPIClient(
-		config.Env("anything"),
+	client, err := stytchapi.NewClient(
 		"project-test-00000000-0000-0000-0000-000000000000",
 		"secret-test-11111111-1111-1111-1111-111111111111",
 		stytchapi.WithBaseURI(srv.URL),
@@ -365,8 +364,7 @@ func ExampleClient_AuthenticateWithClaims_map() {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 	}))
 
-	client, _ := stytchapi.NewAPIClient(
-		config.Env("anything"),
+	client, _ := stytchapi.NewClient(
 		"project-test-00000000-0000-0000-0000-000000000000",
 		"secret-test-11111111-1111-1111-1111-111111111111",
 		stytchapi.WithBaseURI(srv.URL),
@@ -425,8 +423,7 @@ func ExampleClient_AuthenticateWithClaims_struct() {
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 	}))
 
-	client, _ := stytchapi.NewAPIClient(
-		config.Env("anything"),
+	client, _ := stytchapi.NewClient(
 		"project-test-00000000-0000-0000-0000-000000000000",
 		"secret-test-11111111-1111-1111-1111-111111111111",
 		stytchapi.WithBaseURI(srv.URL),

--- a/stytch/b2c/stytchapi/stytchapi.go
+++ b/stytch/b2c/stytchapi/stytchapi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/stytchauth/stytch-go/v8/stytch/b2c/cryptowallet"
@@ -65,6 +66,22 @@ func WithHTTPClient(client *http.Client) Option {
 // this client to access internal development versions of the API.
 func WithBaseURI(uri string) Option {
 	return func(api *API) { api.client.Config.BaseURI = config.BaseURI(uri) }
+}
+
+// NewClient returns a Stytch API client that uses the provided credentials.
+//
+// It detects the environment from the given projectID. You are still free to pass WithBaseURI as an option if you wish
+// to override this behavior, but the intention is to provide a simpler interface for creating a client since it's
+// extremely rare that developers would want to use something other than the detected environment.
+func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
+	var detectedEnv config.Env
+	if strings.HasPrefix(projectID, "project-live-") {
+		detectedEnv = config.EnvLive
+	} else {
+		detectedEnv = config.EnvTest
+	}
+
+	return NewAPIClient(detectedEnv, projectID, secret, opts...)
 }
 
 // NewAPIClient returns a Stytch API client that uses the provided credentials.

--- a/stytch/b2c/stytchapi/stytchapi.go
+++ b/stytch/b2c/stytchapi/stytchapi.go
@@ -97,8 +97,9 @@ func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
 
 // NewAPIClient returns a Stytch API client that uses the provided credentials.
 //
-// It is highly recommended to use NewClient instead of this function since it will automatically detect the correct
-// Stytch environment from the provided projectID. This function will be deprecated in a future MAJOR release.
+// Deprecated: This method requires explicitly supplying a config.Env instead of detecting it automatically, which can
+// lead to bugs when the env does not match what's expected from the given projectID. Use NewClient instead and supply a
+// WithBaseURI if you need to explicitly override the client's BaseURI (typically only done for internal development).
 func NewAPIClient(env config.Env, projectID string, secret string, opts ...Option) (*API, error) {
 	return NewAPIClientWithContext(context.Background(), env, projectID, secret, opts...)
 }
@@ -110,10 +111,11 @@ func NewAPIClient(env config.Env, projectID string, secret string, opts ...Optio
 // creation. After the client is created and returned by this function, canceling the context has
 // no effect.
 //
-// It is highly recommended to use NewClient instead of this function since it will automatically detect the correct
-// Stytch environment from the provided projectID. If you wish to supply your own context, NewClient can be used in
-// conjunction with the WithInitializationContext option to provide the same functionality as this function. This
-// function will be deprecated in a future MAJOR release.
+// Deprecated: This method requires explicitly supplying a config.Env instead of detecting it automatically, which can
+// lead to bugs when the env does not match what's expected from the given projectID. Use NewClient instead and supply a
+// WithBaseURI if you need to explicitly override the client's BaseURI (typically only done for internal development).
+// To supply your own context, additionally use the WithInitializationContext option to provide the same functionality
+// as this function.
 func NewAPIClientWithContext(ctx context.Context, env config.Env, projectID string, secret string, opts ...Option) (*API, error) {
 	a := &API{
 		client:                stytch.New(env, projectID, secret),

--- a/stytch/b2c/stytchapi/stytchapi_test.go
+++ b/stytch/b2c/stytchapi/stytchapi_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/config"
 )
 
 func TestNewClient(t *testing.T) {
@@ -37,8 +36,7 @@ func TestNewClient(t *testing.T) {
 			http.Error(w, "Bad Request", http.StatusBadRequest)
 		}))
 
-		client, err := stytchapi.NewAPIClient(
-			config.Env("anything"),
+		client, err := stytchapi.NewClient(
 			"project-test-00000000-0000-0000-0000-000000000000",
 			"secret-test-11111111-1111-1111-1111-111111111111",
 			stytchapi.WithBaseURI(srv.URL),
@@ -79,8 +77,7 @@ func TestNewClient(t *testing.T) {
 			}),
 		}
 
-		client, err := stytchapi.NewAPIClient(
-			stytch.EnvTest,
+		client, err := stytchapi.NewClient(
 			"project-test-00000000-0000-0000-0000-000000000000",
 			"secret-test-11111111-1111-1111-1111-111111111111",
 			stytchapi.WithHTTPClient(httpClient),
@@ -122,8 +119,7 @@ func TestNewClient(t *testing.T) {
 			}),
 		}
 
-		_, err := stytchapi.NewAPIClient(
-			stytch.EnvTest,
+		_, err := stytchapi.NewClient(
 			"project-test-00000000-0000-0000-0000-000000000000",
 			"secret-test-11111111-1111-1111-1111-111111111111",
 			stytchapi.WithHTTPClient(httpClient),

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-const APIVersion = "8.3.0"
+const APIVersion = "8.4.0"
 
 type BaseURI string
 


### PR DESCRIPTION
It's rare that someone would manually specify the environment unless they were working on something internally and wanted to hit internal development URLs. For every customer, they'd want the environment inferred from the given project ID (a test project can't be used in the live environment and vice versa).

This PR makes env an optional parameter and then sets it later depending on whether the project_id starts with `project-live-`.