### PR TITLE
Publish release whenever version.go is updated

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -16,7 +16,6 @@ jobs:
         run: |
           VERSION=$(sed -n 's/.*APIVersion = "\(.*\)".*/\1/p' stytch/config/version.go)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "release_tag=v$VERSION" >> $GITHUB_OUTPUT
 
       - name: Get changed files
         id: files
@@ -27,7 +26,7 @@ jobs:
         run: |
           FOUND=0
           for changed_file in ${{ steps.files.outputs.all }}; do
-            if [[ $changed_file == "stytch/config/version.go" ]]; then
+            if [[ "$changed_file" == "stytch/config/version.go" ]]; then
               FOUND=1
             fi
           done
@@ -35,10 +34,6 @@ jobs:
 
       - name: Create release draft
         if: steps.diff.outputs.diff != 0
-        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.version.outputs.release_tag }}
-          release_name: ${{ steps.version.outputs.release_tag }}
-          draft: true
+        run: gh release create ${{ steps.version.outputs.version }} --generate-notes

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,44 @@
+name: Publish GitHub release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish GitHub release
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(sed -n 's/.*APIVersion = "\(.*\)".*/\1/p' stytch/config/version.go)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "release_tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Get changed files
+        id: files
+        uses: jitterbit/get-changed-files@v1
+
+      - name: Check for config.go diff
+        id: diff
+        run: |
+          FOUND=0
+          for changed_file in ${{ steps.files.outputs.all }}; do
+            if [[ $changed_file == "stytch/config/version.go" ]]; then
+              FOUND=1
+            fi
+          done
+          echo "diff=$FOUND" >> $GITHUB_OUTPUT
+
+      - name: Create release draft
+        if: steps.diff.outputs.diff != 0
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.version.outputs.release_tag }}
+          release_name: ${{ steps.version.outputs.release_tag }}
+          draft: true

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,10 @@ help:
 .PHONY: lint
 lint:
 	golangci-lint run --fix
+
+.PHONY: test
+test:
+	go test ./stytch/...
+
+.PHONY: tests
+tests: test # A useful alias

--- a/stytch/config/config.go
+++ b/stytch/config/config.go
@@ -1,7 +1,5 @@
 package config
 
-const APIVersion = "8.4.0"
-
 type BaseURI string
 
 const (

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,0 +1,3 @@
+package config
+
+const APIVersion = "8.4.1"


### PR DESCRIPTION
Auto-publish release when version.go is updated

Moves APIVersion from `config/config.go` to `config/version.go`, but within the same package so no imports need to change.

The reason why we move `version.go` into its own file is that we detect a release by this version being updated. The only reason to ever modify `version.go` is to update the version, but `config.go` could reasonably be updated for other changes when someone *doesn't* wish to release a new version.