### PR TITLE
[auto-publish] Add leading v for version string

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -15,7 +15,7 @@ jobs:
         id: version
         run: |
           VERSION=$(sed -n 's/.*APIVersion = "\(.*\)".*/\1/p' stytch/config/version.go)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "release_tag=v$VERSION" >> $GITHUB_OUTPUT
 
       - name: Get changed files
         id: files
@@ -32,8 +32,8 @@ jobs:
           done
           echo "diff=$FOUND" >> $GITHUB_OUTPUT
 
-      - name: Create release draft
+      - name: Create release
         if: steps.diff.outputs.diff != 0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create ${{ steps.version.outputs.version }} --generate-notes
+        run: gh release create ${{ steps.version.outputs.release_tag }} --generate-notes


### PR DESCRIPTION
Action failed with a 500 error, which I'm *guessing* is due to the missing leading `v` since running `gh release create` locally succeeded.