### PR TITLE
Add User to OAuthAuthenticateResponse

### DIFF
--- a/stytch/b2c/oauth.go
+++ b/stytch/b2c/oauth.go
@@ -47,6 +47,7 @@ type OAuthAuthenticateResponse struct {
 	SessionJWT              string         `json:"session_jwt,omitempty"`
 	ProviderValues          ProviderValues `json:"provider_values,omitempty"`
 	ResetSessions           bool           `json:"reset_sessions,omitempty"`
+	User                    User           `json:"user,omitempty"`
 }
 
 type ProviderValues struct {


### PR DESCRIPTION
Adds the User field to OAuthAuthenticateResponse. This field is documented in the [API reference](https://stytch.com/docs/api/authenticate-magic-link), but currently missing from the OAuthAuthenticateResponse struct. There may be a couple other omissions and/or naming differences between the stytch-go structs and the API docs, but those are not addressed here.

This field is necessary to map authenticated user data to existing data in our "lazy" migration.