### PR TITLE
Bump version with revamp

### DIFF
--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "8.4.1"
+const APIVersion = "9.0.0"


### PR DESCRIPTION
I had run a `clean` on #127 and didn't realize the version change was overridden