### PR TITLE
Use v9 in imports and make stytch.Client an interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It pairs well with the Stytch [Web SDK](https://www.npmjs.com/package/@stytch/st
 ## Install
 
 ```console
-$ go get github.com/stytchauth/stytch-go/v8
+$ go get github.com/stytchauth/stytch-go/v9
 ```
 
 ## Usage
@@ -34,8 +34,8 @@ Create an API client:
 import (
 	"context"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2c/stytchapi"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2c/stytchapi"
 )
 
 stytchAPIClient, err := stytchapi.NewClient(

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stytchauth/stytch-go/v8
+module github.com/stytchauth/stytch-go/v9
 
 go 1.18
 

--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -9,7 +9,6 @@ package b2bstytchapi
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/stytchauth/stytch-go/v9/stytch"
 	"github.com/stytchauth/stytch-go/v9/stytch/b2b"
@@ -21,9 +20,13 @@ type Logger interface {
 }
 
 type API struct {
-	client                *stytch.Client
-	logger                Logger
+	projectID string
+	secret    string
+	baseURI   config.BaseURI
+
+	client                stytch.Client
 	initializationContext context.Context
+	logger                Logger
 
 	Organizations *b2b.OrganizationsClient
 	Sessions      *b2b.SessionsClient
@@ -39,10 +42,26 @@ func WithLogger(logger Logger) Option {
 	return func(api *API) { api.logger = logger }
 }
 
-// WithHTTPClient overrides the HTTP client used by the API client. The default value is
-// &http.Client{}.
+// WithClient overrides the stytch.Client used by the API client. This is useful for completely mocking out requests by
+// using something like GoMock against the stytch.Client interface to customize the responses you receive from API
+// methods.
+//
+// NOTE: You should not use this in conjunction with WithHTTPClient or WithBaseURI since the latter two assume usage of
+// the default stytch.DefaultClient and this method completely overrides it to use anything conforming to the interface.
+func WithClient(client stytch.Client) Option {
+	return func(api *API) { api.client = client }
+}
+
+// WithHTTPClient overrides the HTTP client used by the API client. The default value is &http.Client{}.
+//
+// NOTE: You should not use this in conjunction with the WithClient option since WithClient completely overrides the
+// stytch.Client with one that may not be a stytch.DefaultClient.
 func WithHTTPClient(client *http.Client) Option {
-	return func(api *API) { api.client.HTTPClient = client }
+	return func(api *API) {
+		if defaultClient, ok := api.client.(*stytch.DefaultClient); ok {
+			defaultClient.HTTPClient = client
+		}
+	}
 }
 
 // WithBaseURI overrides the client base URI determined by the environment.
@@ -50,8 +69,16 @@ func WithHTTPClient(client *http.Client) Option {
 // The value derived from stytch.EnvLive or stytch.EnvTest is already correct for production use
 // in the Live or Test environment, respectively. This is implemented to make it easier to use
 // this client to access internal development versions of the API.
+//
+// NOTE: You should not use this in conjunction with the WithClient option since WithClient completely overrides the
+// stytch.Client with one that may not be a stytch.DefaultClient.
 func WithBaseURI(uri string) Option {
-	return func(api *API) { api.client.Config.BaseURI = config.BaseURI(uri) }
+	return func(api *API) {
+		api.baseURI = config.BaseURI(uri)
+		if defaultClient, ok := api.client.(*stytch.DefaultClient); ok {
+			defaultClient.Config.BaseURI = config.BaseURI(uri)
+		}
+	}
 }
 
 // WithInitializationContext overrides the context used during initialization.
@@ -70,15 +97,13 @@ func WithInitializationContext(ctx context.Context) Option {
 // to override this behavior, but the intention is to provide a simpler interface for creating a client since it's
 // extremely rare that developers would want to use something other than the detected environment.
 func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
-	var detectedEnv config.Env
-	if strings.HasPrefix(projectID, "project-live-") {
-		detectedEnv = config.EnvLive
-	} else {
-		detectedEnv = config.EnvTest
-	}
-
+	defaultClient := stytch.New(projectID, secret)
 	a := &API{
-		client:                stytch.New(detectedEnv, projectID, secret),
+		projectID: projectID,
+		secret:    secret,
+		baseURI:   defaultClient.Config.BaseURI,
+
+		client:                defaultClient,
 		initializationContext: context.Background(),
 	}
 	for _, o := range opts {

--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -11,9 +11,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b"
-	"github.com/stytchauth/stytch-go/v8/stytch/config"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b"
+	"github.com/stytchauth/stytch-go/v9/stytch/config"
 )
 
 type Logger interface {

--- a/stytch/b2b/discovery.go
+++ b/stytch/b2b/discovery.go
@@ -11,12 +11,12 @@ import (
 )
 
 type DiscoveryClient struct {
-	C                    *stytch.Client
+	C                    stytch.Client
 	IntermediateSessions *DiscoveryIntermediateSessionsClient
 	Organizations        *DiscoveryOrganizationsClient
 }
 
-func NewDiscoveryClient(c *stytch.Client) *DiscoveryClient {
+func NewDiscoveryClient(c stytch.Client) *DiscoveryClient {
 	return &DiscoveryClient{
 		C:                    c,
 		IntermediateSessions: NewDiscoveryIntermediateSessionsClient(c),

--- a/stytch/b2b/discovery.go
+++ b/stytch/b2b/discovery.go
@@ -7,7 +7,7 @@ package b2b
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch"
 )
 
 type DiscoveryClient struct {

--- a/stytch/b2b/discovery/intermediatesessions/types.go
+++ b/stytch/b2b/discovery/intermediatesessions/types.go
@@ -7,8 +7,8 @@ package intermediatesessions
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sessions"
 )
 
 // ExchangeParams: Request type for `IntermediateSessions.Exchange`.

--- a/stytch/b2b/discovery/organizations/types.go
+++ b/stytch/b2b/discovery/organizations/types.go
@@ -7,9 +7,9 @@ package organizations
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/discovery"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/discovery"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sessions"
 )
 
 // CreateParams: Request type for `Organizations.Create`.

--- a/stytch/b2b/discovery/types.go
+++ b/stytch/b2b/discovery/types.go
@@ -7,7 +7,7 @@ package discovery
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
 )
 
 // DiscoveredOrganization:

--- a/stytch/b2b/discovery_intermediatesessions.go
+++ b/stytch/b2b/discovery_intermediatesessions.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/discovery/intermediatesessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/discovery/intermediatesessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type DiscoveryIntermediateSessionsClient struct {

--- a/stytch/b2b/discovery_intermediatesessions.go
+++ b/stytch/b2b/discovery_intermediatesessions.go
@@ -16,10 +16,10 @@ import (
 )
 
 type DiscoveryIntermediateSessionsClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewDiscoveryIntermediateSessionsClient(c *stytch.Client) *DiscoveryIntermediateSessionsClient {
+func NewDiscoveryIntermediateSessionsClient(c stytch.Client) *DiscoveryIntermediateSessionsClient {
 	return &DiscoveryIntermediateSessionsClient{
 		C: c,
 	}

--- a/stytch/b2b/discovery_organizations.go
+++ b/stytch/b2b/discovery_organizations.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/discovery/organizations"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/discovery/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type DiscoveryOrganizationsClient struct {

--- a/stytch/b2b/discovery_organizations.go
+++ b/stytch/b2b/discovery_organizations.go
@@ -16,10 +16,10 @@ import (
 )
 
 type DiscoveryOrganizationsClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewDiscoveryOrganizationsClient(c *stytch.Client) *DiscoveryOrganizationsClient {
+func NewDiscoveryOrganizationsClient(c stytch.Client) *DiscoveryOrganizationsClient {
 	return &DiscoveryOrganizationsClient{
 		C: c,
 	}

--- a/stytch/b2b/magiclinks.go
+++ b/stytch/b2b/magiclinks.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/magiclinks"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/magiclinks"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type MagicLinksClient struct {

--- a/stytch/b2b/magiclinks.go
+++ b/stytch/b2b/magiclinks.go
@@ -16,12 +16,12 @@ import (
 )
 
 type MagicLinksClient struct {
-	C         *stytch.Client
+	C         stytch.Client
 	Email     *MagicLinksEmailClient
 	Discovery *MagicLinksDiscoveryClient
 }
 
-func NewMagicLinksClient(c *stytch.Client) *MagicLinksClient {
+func NewMagicLinksClient(c stytch.Client) *MagicLinksClient {
 	return &MagicLinksClient{
 		C:         c,
 		Email:     NewMagicLinksEmailClient(c),

--- a/stytch/b2b/magiclinks/discovery/types.go
+++ b/stytch/b2b/magiclinks/discovery/types.go
@@ -7,7 +7,7 @@ package discovery
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/discovery"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/discovery"
 )
 
 // AuthenticateParams: Request type for `Discovery.Authenticate`.

--- a/stytch/b2b/magiclinks/email/types.go
+++ b/stytch/b2b/magiclinks/email/types.go
@@ -7,7 +7,7 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
 )
 
 // InviteParams: Request type for `Email.Invite`.

--- a/stytch/b2b/magiclinks/types.go
+++ b/stytch/b2b/magiclinks/types.go
@@ -7,8 +7,8 @@ package magiclinks
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sessions"
 )
 
 // AuthenticateParams: Request type for `MagicLinks.Authenticate`.

--- a/stytch/b2b/magiclinks_discovery.go
+++ b/stytch/b2b/magiclinks_discovery.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/magiclinks/discovery"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/magiclinks/discovery"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type MagicLinksDiscoveryClient struct {

--- a/stytch/b2b/magiclinks_discovery.go
+++ b/stytch/b2b/magiclinks_discovery.go
@@ -16,10 +16,10 @@ import (
 )
 
 type MagicLinksDiscoveryClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewMagicLinksDiscoveryClient(c *stytch.Client) *MagicLinksDiscoveryClient {
+func NewMagicLinksDiscoveryClient(c stytch.Client) *MagicLinksDiscoveryClient {
 	return &MagicLinksDiscoveryClient{
 		C: c,
 	}

--- a/stytch/b2b/magiclinks_email.go
+++ b/stytch/b2b/magiclinks_email.go
@@ -16,11 +16,11 @@ import (
 )
 
 type MagicLinksEmailClient struct {
-	C         *stytch.Client
+	C         stytch.Client
 	Discovery *MagicLinksEmailDiscoveryClient
 }
 
-func NewMagicLinksEmailClient(c *stytch.Client) *MagicLinksEmailClient {
+func NewMagicLinksEmailClient(c stytch.Client) *MagicLinksEmailClient {
 	return &MagicLinksEmailClient{
 		C:         c,
 		Discovery: NewMagicLinksEmailDiscoveryClient(c),

--- a/stytch/b2b/magiclinks_email.go
+++ b/stytch/b2b/magiclinks_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/magiclinks/email"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/magiclinks/email"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type MagicLinksEmailClient struct {

--- a/stytch/b2b/magiclinks_email_discovery.go
+++ b/stytch/b2b/magiclinks_email_discovery.go
@@ -16,10 +16,10 @@ import (
 )
 
 type MagicLinksEmailDiscoveryClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewMagicLinksEmailDiscoveryClient(c *stytch.Client) *MagicLinksEmailDiscoveryClient {
+func NewMagicLinksEmailDiscoveryClient(c stytch.Client) *MagicLinksEmailDiscoveryClient {
 	return &MagicLinksEmailDiscoveryClient{
 		C: c,
 	}

--- a/stytch/b2b/magiclinks_email_discovery.go
+++ b/stytch/b2b/magiclinks_email_discovery.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/magiclinks/email/discovery"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/magiclinks/email/discovery"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type MagicLinksEmailDiscoveryClient struct {

--- a/stytch/b2b/organizations.go
+++ b/stytch/b2b/organizations.go
@@ -17,11 +17,11 @@ import (
 )
 
 type OrganizationsClient struct {
-	C       *stytch.Client
+	C       stytch.Client
 	Members *OrganizationsMembersClient
 }
 
-func NewOrganizationsClient(c *stytch.Client) *OrganizationsClient {
+func NewOrganizationsClient(c stytch.Client) *OrganizationsClient {
 	return &OrganizationsClient{
 		C:       c,
 		Members: NewOrganizationsMembersClient(c),

--- a/stytch/b2b/organizations.go
+++ b/stytch/b2b/organizations.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type OrganizationsClient struct {

--- a/stytch/b2b/organizations/members/types.go
+++ b/stytch/b2b/organizations/members/types.go
@@ -7,7 +7,7 @@ package members
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
 )
 
 // CreateParams: Request type for `Members.Create`.

--- a/stytch/b2b/organizations_members.go
+++ b/stytch/b2b/organizations_members.go
@@ -17,10 +17,10 @@ import (
 )
 
 type OrganizationsMembersClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewOrganizationsMembersClient(c *stytch.Client) *OrganizationsMembersClient {
+func NewOrganizationsMembersClient(c stytch.Client) *OrganizationsMembersClient {
 	return &OrganizationsMembersClient{
 		C: c,
 	}

--- a/stytch/b2b/organizations_members.go
+++ b/stytch/b2b/organizations_members.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations/members"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations/members"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type OrganizationsMembersClient struct {

--- a/stytch/b2b/passwords.go
+++ b/stytch/b2b/passwords.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/passwords"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/passwords"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type PasswordsClient struct {

--- a/stytch/b2b/passwords.go
+++ b/stytch/b2b/passwords.go
@@ -16,13 +16,13 @@ import (
 )
 
 type PasswordsClient struct {
-	C                *stytch.Client
+	C                stytch.Client
 	Email            *PasswordsEmailClient
 	Sessions         *PasswordsSessionsClient
 	ExistingPassword *PasswordsExistingPasswordClient
 }
 
-func NewPasswordsClient(c *stytch.Client) *PasswordsClient {
+func NewPasswordsClient(c stytch.Client) *PasswordsClient {
 	return &PasswordsClient{
 		C:                c,
 		Email:            NewPasswordsEmailClient(c),

--- a/stytch/b2b/passwords/email/types.go
+++ b/stytch/b2b/passwords/email/types.go
@@ -7,8 +7,8 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sessions"
 )
 
 // ResetParams: Request type for `Email.Reset`.

--- a/stytch/b2b/passwords/existingpassword/types.go
+++ b/stytch/b2b/passwords/existingpassword/types.go
@@ -7,8 +7,8 @@ package existingpassword
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sessions"
 )
 
 // ResetParams: Request type for `ExistingPassword.Reset`.

--- a/stytch/b2b/passwords/session/types.go
+++ b/stytch/b2b/passwords/session/types.go
@@ -7,8 +7,8 @@ package session
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sessions"
 )
 
 // ResetParams: Request type for `Sessions.Reset`.

--- a/stytch/b2b/passwords/types.go
+++ b/stytch/b2b/passwords/types.go
@@ -7,9 +7,9 @@ package passwords
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/passwords"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/passwords"
 )
 
 // AuthenticateParams: Request type for `Passwords.Authenticate`.

--- a/stytch/b2b/passwords_email.go
+++ b/stytch/b2b/passwords_email.go
@@ -16,10 +16,10 @@ import (
 )
 
 type PasswordsEmailClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewPasswordsEmailClient(c *stytch.Client) *PasswordsEmailClient {
+func NewPasswordsEmailClient(c stytch.Client) *PasswordsEmailClient {
 	return &PasswordsEmailClient{
 		C: c,
 	}

--- a/stytch/b2b/passwords_email.go
+++ b/stytch/b2b/passwords_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/passwords/email"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/passwords/email"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type PasswordsEmailClient struct {

--- a/stytch/b2b/passwords_existingpassword.go
+++ b/stytch/b2b/passwords_existingpassword.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/passwords/existingpassword"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/passwords/existingpassword"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type PasswordsExistingPasswordClient struct {

--- a/stytch/b2b/passwords_existingpassword.go
+++ b/stytch/b2b/passwords_existingpassword.go
@@ -16,10 +16,10 @@ import (
 )
 
 type PasswordsExistingPasswordClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewPasswordsExistingPasswordClient(c *stytch.Client) *PasswordsExistingPasswordClient {
+func NewPasswordsExistingPasswordClient(c stytch.Client) *PasswordsExistingPasswordClient {
 	return &PasswordsExistingPasswordClient{
 		C: c,
 	}

--- a/stytch/b2b/passwords_session.go
+++ b/stytch/b2b/passwords_session.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/passwords/session"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/passwords/session"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type PasswordsSessionsClient struct {

--- a/stytch/b2b/passwords_session.go
+++ b/stytch/b2b/passwords_session.go
@@ -16,10 +16,10 @@ import (
 )
 
 type PasswordsSessionsClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewPasswordsSessionsClient(c *stytch.Client) *PasswordsSessionsClient {
+func NewPasswordsSessionsClient(c stytch.Client) *PasswordsSessionsClient {
 	return &PasswordsSessionsClient{
 		C: c,
 	}

--- a/stytch/b2b/sessions.go
+++ b/stytch/b2b/sessions.go
@@ -17,10 +17,10 @@ import (
 )
 
 type SessionsClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewSessionsClient(c *stytch.Client) *SessionsClient {
+func NewSessionsClient(c stytch.Client) *SessionsClient {
 	return &SessionsClient{
 		C: c,
 	}

--- a/stytch/b2b/sessions.go
+++ b/stytch/b2b/sessions.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type SessionsClient struct {

--- a/stytch/b2b/sessions/types.go
+++ b/stytch/b2b/sessions/types.go
@@ -9,8 +9,8 @@ package sessions
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
 )
 
 // AuthenticateParams: Request type for `Sessions.Authenticate`.

--- a/stytch/b2b/sso.go
+++ b/stytch/b2b/sso.go
@@ -17,12 +17,12 @@ import (
 )
 
 type SSOClient struct {
-	C    *stytch.Client
+	C    stytch.Client
 	OIDC *SSOOIDCClient
 	SAML *SSOSAMLClient
 }
 
-func NewSSOClient(c *stytch.Client) *SSOClient {
+func NewSSOClient(c stytch.Client) *SSOClient {
 	return &SSOClient{
 		C:    c,
 		OIDC: NewSSOOIDCClient(c),

--- a/stytch/b2b/sso.go
+++ b/stytch/b2b/sso.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sso"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sso"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type SSOClient struct {

--- a/stytch/b2b/sso/oidc/types.go
+++ b/stytch/b2b/sso/oidc/types.go
@@ -7,7 +7,7 @@ package oidc
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sso"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sso"
 )
 
 // CreateConnectionParams: Request type for `OIDC.CreateConnection`.

--- a/stytch/b2b/sso/saml/types.go
+++ b/stytch/b2b/sso/saml/types.go
@@ -7,7 +7,7 @@ package saml
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sso"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sso"
 )
 
 // CreateConnectionParams: Request type for `SAML.CreateConnection`.

--- a/stytch/b2b/sso/types.go
+++ b/stytch/b2b/sso/types.go
@@ -9,8 +9,8 @@ package sso
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sessions"
 )
 
 // AuthenticateParams: Request type for `SSO.Authenticate`.

--- a/stytch/b2b/sso_oidc.go
+++ b/stytch/b2b/sso_oidc.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sso/oidc"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sso/oidc"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type SSOOIDCClient struct {

--- a/stytch/b2b/sso_oidc.go
+++ b/stytch/b2b/sso_oidc.go
@@ -17,10 +17,10 @@ import (
 )
 
 type SSOOIDCClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewSSOOIDCClient(c *stytch.Client) *SSOOIDCClient {
+func NewSSOOIDCClient(c stytch.Client) *SSOOIDCClient {
 	return &SSOOIDCClient{
 		C: c,
 	}

--- a/stytch/b2b/sso_saml.go
+++ b/stytch/b2b/sso_saml.go
@@ -17,10 +17,10 @@ import (
 )
 
 type SSOSAMLClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewSSOSAMLClient(c *stytch.Client) *SSOSAMLClient {
+func NewSSOSAMLClient(c stytch.Client) *SSOSAMLClient {
 	return &SSOSAMLClient{
 		C: c,
 	}

--- a/stytch/b2b/sso_saml.go
+++ b/stytch/b2b/sso_saml.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/b2b/sso/saml"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/b2b/sso/saml"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type SSOSAMLClient struct {

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "9.0.1"
+const APIVersion = "9.0.0"

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "9.0.0"
+const APIVersion = "9.0.1"

--- a/stytch/consumer/cryptowallets.go
+++ b/stytch/consumer/cryptowallets.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/cryptowallets"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/cryptowallets"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type CryptoWalletsClient struct {

--- a/stytch/consumer/cryptowallets.go
+++ b/stytch/consumer/cryptowallets.go
@@ -18,10 +18,10 @@ import (
 )
 
 type CryptoWalletsClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewCryptoWalletsClient(c *stytch.Client) *CryptoWalletsClient {
+func NewCryptoWalletsClient(c stytch.Client) *CryptoWalletsClient {
 	return &CryptoWalletsClient{
 		C: c,
 	}

--- a/stytch/consumer/cryptowallets/types.go
+++ b/stytch/consumer/cryptowallets/types.go
@@ -7,8 +7,8 @@ package cryptowallets
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `CryptoWallets.Authenticate`.

--- a/stytch/consumer/magiclinks.go
+++ b/stytch/consumer/magiclinks.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type MagicLinksClient struct {

--- a/stytch/consumer/magiclinks.go
+++ b/stytch/consumer/magiclinks.go
@@ -18,11 +18,11 @@ import (
 )
 
 type MagicLinksClient struct {
-	C     *stytch.Client
+	C     stytch.Client
 	Email *MagicLinksEmailClient
 }
 
-func NewMagicLinksClient(c *stytch.Client) *MagicLinksClient {
+func NewMagicLinksClient(c stytch.Client) *MagicLinksClient {
 	return &MagicLinksClient{
 		C:     c,
 		Email: NewMagicLinksEmailClient(c),

--- a/stytch/consumer/magiclinks/email/types.go
+++ b/stytch/consumer/magiclinks/email/types.go
@@ -7,8 +7,8 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 // InviteParams: Request type for `Email.Invite`.

--- a/stytch/consumer/magiclinks/types.go
+++ b/stytch/consumer/magiclinks/types.go
@@ -7,9 +7,9 @@ package magiclinks
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `MagicLinks.Authenticate`.

--- a/stytch/consumer/magiclinks_email.go
+++ b/stytch/consumer/magiclinks_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/magiclinks/email"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/magiclinks/email"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type MagicLinksEmailClient struct {

--- a/stytch/consumer/magiclinks_email.go
+++ b/stytch/consumer/magiclinks_email.go
@@ -16,10 +16,10 @@ import (
 )
 
 type MagicLinksEmailClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewMagicLinksEmailClient(c *stytch.Client) *MagicLinksEmailClient {
+func NewMagicLinksEmailClient(c stytch.Client) *MagicLinksEmailClient {
 	return &MagicLinksEmailClient{
 		C: c,
 	}

--- a/stytch/consumer/oauth.go
+++ b/stytch/consumer/oauth.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/oauth"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/oauth"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type OAuthClient struct {

--- a/stytch/consumer/oauth.go
+++ b/stytch/consumer/oauth.go
@@ -18,10 +18,10 @@ import (
 )
 
 type OAuthClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewOAuthClient(c *stytch.Client) *OAuthClient {
+func NewOAuthClient(c stytch.Client) *OAuthClient {
 	return &OAuthClient{
 		C: c,
 	}

--- a/stytch/consumer/oauth/types.go
+++ b/stytch/consumer/oauth/types.go
@@ -9,8 +9,8 @@ package oauth
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 // AttachParams: Request type for `OAuth.Attach`.

--- a/stytch/consumer/otp.go
+++ b/stytch/consumer/otp.go
@@ -18,13 +18,13 @@ import (
 )
 
 type OTPsClient struct {
-	C        *stytch.Client
+	C        stytch.Client
 	Sms      *OTPsSmsClient
 	Whatsapp *OTPsWhatsappClient
 	Email    *OTPsEmailClient
 }
 
-func NewOTPsClient(c *stytch.Client) *OTPsClient {
+func NewOTPsClient(c stytch.Client) *OTPsClient {
 	return &OTPsClient{
 		C:        c,
 		Sms:      NewOTPsSmsClient(c),

--- a/stytch/consumer/otp.go
+++ b/stytch/consumer/otp.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/otp"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/otp"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type OTPsClient struct {

--- a/stytch/consumer/otp/email/types.go
+++ b/stytch/consumer/otp/email/types.go
@@ -7,7 +7,7 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/attribute"
 )
 
 // LoginOrCreateParams: Request type for `Email.LoginOrCreate`.

--- a/stytch/consumer/otp/sms/types.go
+++ b/stytch/consumer/otp/sms/types.go
@@ -7,7 +7,7 @@ package sms
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/attribute"
 )
 
 // LoginOrCreateParams: Request type for `Sms.LoginOrCreate`.

--- a/stytch/consumer/otp/types.go
+++ b/stytch/consumer/otp/types.go
@@ -7,10 +7,10 @@ package otp
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `OTPs.Authenticate`.

--- a/stytch/consumer/otp/whatsapp/types.go
+++ b/stytch/consumer/otp/whatsapp/types.go
@@ -7,7 +7,7 @@ package whatsapp
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/attribute"
 )
 
 // LoginOrCreateParams: Request type for `Whatsapp.LoginOrCreate`.

--- a/stytch/consumer/otp_email.go
+++ b/stytch/consumer/otp_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/otp/email"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/otp/email"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type OTPsEmailClient struct {

--- a/stytch/consumer/otp_email.go
+++ b/stytch/consumer/otp_email.go
@@ -16,10 +16,10 @@ import (
 )
 
 type OTPsEmailClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewOTPsEmailClient(c *stytch.Client) *OTPsEmailClient {
+func NewOTPsEmailClient(c stytch.Client) *OTPsEmailClient {
 	return &OTPsEmailClient{
 		C: c,
 	}

--- a/stytch/consumer/otp_sms.go
+++ b/stytch/consumer/otp_sms.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/otp/sms"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/otp/sms"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type OTPsSmsClient struct {

--- a/stytch/consumer/otp_sms.go
+++ b/stytch/consumer/otp_sms.go
@@ -16,10 +16,10 @@ import (
 )
 
 type OTPsSmsClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewOTPsSmsClient(c *stytch.Client) *OTPsSmsClient {
+func NewOTPsSmsClient(c stytch.Client) *OTPsSmsClient {
 	return &OTPsSmsClient{
 		C: c,
 	}

--- a/stytch/consumer/otp_whatsapp.go
+++ b/stytch/consumer/otp_whatsapp.go
@@ -16,10 +16,10 @@ import (
 )
 
 type OTPsWhatsappClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewOTPsWhatsappClient(c *stytch.Client) *OTPsWhatsappClient {
+func NewOTPsWhatsappClient(c stytch.Client) *OTPsWhatsappClient {
 	return &OTPsWhatsappClient{
 		C: c,
 	}

--- a/stytch/consumer/otp_whatsapp.go
+++ b/stytch/consumer/otp_whatsapp.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/otp/whatsapp"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/otp/whatsapp"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type OTPsWhatsappClient struct {

--- a/stytch/consumer/passwords.go
+++ b/stytch/consumer/passwords.go
@@ -18,13 +18,13 @@ import (
 )
 
 type PasswordsClient struct {
-	C                *stytch.Client
+	C                stytch.Client
 	Email            *PasswordsEmailClient
 	ExistingPassword *PasswordsExistingPasswordClient
 	Sessions         *PasswordsSessionsClient
 }
 
-func NewPasswordsClient(c *stytch.Client) *PasswordsClient {
+func NewPasswordsClient(c stytch.Client) *PasswordsClient {
 	return &PasswordsClient{
 		C:                c,
 		Email:            NewPasswordsEmailClient(c),

--- a/stytch/consumer/passwords.go
+++ b/stytch/consumer/passwords.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/passwords"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/passwords"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type PasswordsClient struct {

--- a/stytch/consumer/passwords/email/types.go
+++ b/stytch/consumer/passwords/email/types.go
@@ -7,10 +7,10 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 // ResetParams: Request type for `Email.Reset`.

--- a/stytch/consumer/passwords/existingpassword/types.go
+++ b/stytch/consumer/passwords/existingpassword/types.go
@@ -7,8 +7,8 @@ package existingpassword
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 // ResetParams: Request type for `ExistingPassword.Reset`.

--- a/stytch/consumer/passwords/session/types.go
+++ b/stytch/consumer/passwords/session/types.go
@@ -7,8 +7,8 @@ package session
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 // ResetParams: Request type for `Sessions.Reset`.

--- a/stytch/consumer/passwords/types.go
+++ b/stytch/consumer/passwords/types.go
@@ -7,8 +7,8 @@ package passwords
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 // Argon2Config:

--- a/stytch/consumer/passwords_email.go
+++ b/stytch/consumer/passwords_email.go
@@ -16,10 +16,10 @@ import (
 )
 
 type PasswordsEmailClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewPasswordsEmailClient(c *stytch.Client) *PasswordsEmailClient {
+func NewPasswordsEmailClient(c stytch.Client) *PasswordsEmailClient {
 	return &PasswordsEmailClient{
 		C: c,
 	}

--- a/stytch/consumer/passwords_email.go
+++ b/stytch/consumer/passwords_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/passwords/email"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/passwords/email"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type PasswordsEmailClient struct {

--- a/stytch/consumer/passwords_existingpassword.go
+++ b/stytch/consumer/passwords_existingpassword.go
@@ -16,10 +16,10 @@ import (
 )
 
 type PasswordsExistingPasswordClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewPasswordsExistingPasswordClient(c *stytch.Client) *PasswordsExistingPasswordClient {
+func NewPasswordsExistingPasswordClient(c stytch.Client) *PasswordsExistingPasswordClient {
 	return &PasswordsExistingPasswordClient{
 		C: c,
 	}

--- a/stytch/consumer/passwords_existingpassword.go
+++ b/stytch/consumer/passwords_existingpassword.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/passwords/existingpassword"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/passwords/existingpassword"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type PasswordsExistingPasswordClient struct {

--- a/stytch/consumer/passwords_session.go
+++ b/stytch/consumer/passwords_session.go
@@ -16,10 +16,10 @@ import (
 )
 
 type PasswordsSessionsClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewPasswordsSessionsClient(c *stytch.Client) *PasswordsSessionsClient {
+func NewPasswordsSessionsClient(c stytch.Client) *PasswordsSessionsClient {
 	return &PasswordsSessionsClient{
 		C: c,
 	}

--- a/stytch/consumer/passwords_session.go
+++ b/stytch/consumer/passwords_session.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/passwords/session"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/passwords/session"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type PasswordsSessionsClient struct {

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -15,9 +15,9 @@ import (
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type SessionsClient struct {

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -21,11 +21,11 @@ import (
 )
 
 type SessionsClient struct {
-	C    *stytch.Client
+	C    stytch.Client
 	JWKS *keyfunc.JWKS
 }
 
-func NewSessionsClient(c *stytch.Client) *SessionsClient {
+func NewSessionsClient(c stytch.Client) *SessionsClient {
 	return &SessionsClient{
 		C: c,
 	}
@@ -243,8 +243,8 @@ func (c *SessionsClient) AuthenticateJWTLocal(
 ) (*sessions.Session, error) {
 	var claims sessions.Claims
 
-	aud := c.C.Config.BasicAuthProjectID()
-	iss := fmt.Sprintf("stytch.com/%s", c.C.Config.BasicAuthProjectID())
+	aud := c.C.GetConfig().ProjectID
+	iss := fmt.Sprintf("stytch.com/%s", c.C.GetConfig().ProjectID)
 
 	_, err := jwt.ParseWithClaims(token, &claims, c.JWKS.Keyfunc, jwt.WithAudience(aud), jwt.WithIssuer(iss))
 	if err != nil {

--- a/stytch/consumer/sessions/types.go
+++ b/stytch/consumer/sessions/types.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 type AmazonOAuthFactor struct {

--- a/stytch/consumer/sessions_test.go
+++ b/stytch/consumer/sessions_test.go
@@ -11,17 +11,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/stytchapi"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/stytchapi"
 
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/config"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/config"
 )
 
 func TestAuthenticateJWTLocal(t *testing.T) {

--- a/stytch/consumer/sessions_test.go
+++ b/stytch/consumer/sessions_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestAuthenticateJWTLocal(t *testing.T) {
-	client := &stytch.Client{
+	client := &stytch.DefaultClient{
 		Config: &config.Config{
 			Env:       config.EnvTest,
 			BaseURI:   "https://example.test/v1/",

--- a/stytch/consumer/stytchapi/stytchapi.go
+++ b/stytch/consumer/stytchapi/stytchapi.go
@@ -14,9 +14,9 @@ import (
 	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/config"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/config"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer"
 )
 
 type Logger interface {

--- a/stytch/consumer/stytchapi/stytchapi.go
+++ b/stytch/consumer/stytchapi/stytchapi.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
@@ -24,9 +23,13 @@ type Logger interface {
 }
 
 type API struct {
-	client                *stytch.Client
-	logger                Logger
+	projectID string
+	secret    string
+	baseURI   config.BaseURI
+
+	client                stytch.Client
 	initializationContext context.Context
+	logger                Logger
 
 	Users         *consumer.UsersClient
 	Sessions      *consumer.SessionsClient
@@ -45,10 +48,26 @@ func WithLogger(logger Logger) Option {
 	return func(api *API) { api.logger = logger }
 }
 
-// WithHTTPClient overrides the HTTP client used by the API client. The default value is
-// &http.Client{}.
+// WithClient overrides the stytch.Client used by the API client. This is useful for completely mocking out requests by
+// using something like GoMock against the stytch.Client interface to customize the responses you receive from API
+// methods.
+//
+// NOTE: You should not use this in conjunction with WithHTTPClient or WithBaseURI since the latter two assume usage of
+// the default stytch.DefaultClient and this method completely overrides it to use anything conforming to the interface.
+func WithClient(client stytch.Client) Option {
+	return func(api *API) { api.client = client }
+}
+
+// WithHTTPClient overrides the HTTP client used by the API client. The default value is &http.Client{}.
+//
+// NOTE: You should not use this in conjunction with the WithClient option since WithClient completely overrides the
+// stytch.Client with one that may not be a stytch.DefaultClient.
 func WithHTTPClient(client *http.Client) Option {
-	return func(api *API) { api.client.HTTPClient = client }
+	return func(api *API) {
+		if defaultClient, ok := api.client.(*stytch.DefaultClient); ok {
+			defaultClient.HTTPClient = client
+		}
+	}
 }
 
 // WithBaseURI overrides the client base URI determined by the environment.
@@ -56,8 +75,16 @@ func WithHTTPClient(client *http.Client) Option {
 // The value derived from stytch.EnvLive or stytch.EnvTest is already correct for production use
 // in the Live or Test environment, respectively. This is implemented to make it easier to use
 // this client to access internal development versions of the API.
+//
+// NOTE: You should not use this in conjunction with the WithClient option since WithClient completely overrides the
+// stytch.Client with one that may not be a stytch.DefaultClient.
 func WithBaseURI(uri string) Option {
-	return func(api *API) { api.client.Config.BaseURI = config.BaseURI(uri) }
+	return func(api *API) {
+		api.baseURI = config.BaseURI(uri)
+		if defaultClient, ok := api.client.(*stytch.DefaultClient); ok {
+			defaultClient.Config.BaseURI = config.BaseURI(uri)
+		}
+	}
 }
 
 // WithInitializationContext overrides the context used during initialization.
@@ -76,15 +103,13 @@ func WithInitializationContext(ctx context.Context) Option {
 // to override this behavior, but the intention is to provide a simpler interface for creating a client since it's
 // extremely rare that developers would want to use something other than the detected environment.
 func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
-	var detectedEnv config.Env
-	if strings.HasPrefix(projectID, "project-live-") {
-		detectedEnv = config.EnvLive
-	} else {
-		detectedEnv = config.EnvTest
-	}
-
+	defaultClient := stytch.New(projectID, secret)
 	a := &API{
-		client:                stytch.New(detectedEnv, projectID, secret),
+		projectID: projectID,
+		secret:    secret,
+		baseURI:   defaultClient.Config.BaseURI,
+
+		client:                defaultClient,
 		initializationContext: context.Background(),
 	}
 	for _, o := range opts {
@@ -101,7 +126,11 @@ func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
 	a.TOTPs = consumer.NewTOTPsClient(a.client)
 	a.WebAuthn = consumer.NewWebAuthnClient(a.client)
 	// Set up JWKS for local session authentication
-	jwks, err := a.instantiateJWKSClient(a.initializationContext, a.client)
+	httpClient := defaultClient.HTTPClient
+	if realClient, ok := a.client.(*stytch.DefaultClient); ok {
+		httpClient = realClient.HTTPClient
+	}
+	jwks, err := a.instantiateJWKSClient(httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("fetch JWKS from URL: %w", err)
 	}
@@ -110,14 +139,14 @@ func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
 	return a, nil
 }
 
-func (a *API) instantiateJWKSClient(ctx context.Context, client *stytch.Client) (*keyfunc.JWKS, error) {
+func (a *API) instantiateJWKSClient(httpClient *http.Client) (*keyfunc.JWKS, error) {
 	// The context given in the keyfunc Options applies throughout the lifetime of the JWKS
 	// fetcher. The context we were given here is _only_ for init, so we arrange to cancel the
 	// JWKS context manually if we couldn't start in time.
-	jwksCtx, jwksCancel := context.WithCancel(ctx)
+	jwksCtx, jwksCancel := context.WithCancel(a.initializationContext)
 
 	jwkOptions := keyfunc.Options{
-		Client: client.HTTPClient,
+		Client: httpClient,
 
 		// This is the context for ongoing background JWKS fetches. If the keyfunc starts in time,
 		// it should run until API.Close is called.
@@ -134,9 +163,7 @@ func (a *API) instantiateJWKSClient(ctx context.Context, client *stytch.Client) 
 		RefreshUnknownKID: true,
 	}
 
-	baseURI := client.Config.GetBaseURI()
-	projectID := client.Config.BasicAuthProjectID()
-	jwksURL := fmt.Sprintf("%s/v1/sessions/jwks/%s", baseURI, projectID)
+	jwksURL := fmt.Sprintf("%s/v1/sessions/jwks/%s", a.baseURI, a.projectID)
 
 	type Res struct {
 		jwks *keyfunc.JWKS
@@ -149,10 +176,10 @@ func (a *API) instantiateJWKSClient(ctx context.Context, client *stytch.Client) 
 	}()
 
 	select {
-	case <-ctx.Done():
+	case <-a.initializationContext.Done():
 		// Couldn't start in time, clean up the JWKS.
 		jwksCancel()
-		return nil, ctx.Err()
+		return nil, a.initializationContext.Err()
 	case res := <-res:
 		// JWKS setup finished first, _do not_ cancel its context. Let it continue fetching in the
 		// background.

--- a/stytch/consumer/stytchapi/stytchapi_test.go
+++ b/stytch/consumer/stytchapi/stytchapi_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/stytchapi"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/stytchapi"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/stytch/consumer/totps.go
+++ b/stytch/consumer/totps.go
@@ -18,10 +18,10 @@ import (
 )
 
 type TOTPsClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewTOTPsClient(c *stytch.Client) *TOTPsClient {
+func NewTOTPsClient(c stytch.Client) *TOTPsClient {
 	return &TOTPsClient{
 		C: c,
 	}

--- a/stytch/consumer/totps.go
+++ b/stytch/consumer/totps.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/totps"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/totps"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type TOTPsClient struct {

--- a/stytch/consumer/totps/types.go
+++ b/stytch/consumer/totps/types.go
@@ -7,8 +7,8 @@ package totps
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `TOTPs.Authenticate`.

--- a/stytch/consumer/users.go
+++ b/stytch/consumer/users.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type UsersClient struct {

--- a/stytch/consumer/users.go
+++ b/stytch/consumer/users.go
@@ -17,10 +17,10 @@ import (
 )
 
 type UsersClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewUsersClient(c *stytch.Client) *UsersClient {
+func NewUsersClient(c stytch.Client) *UsersClient {
 	return &UsersClient{
 		C: c,
 	}

--- a/stytch/consumer/users/types.go
+++ b/stytch/consumer/users/types.go
@@ -9,7 +9,7 @@ package users
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/attribute"
 )
 
 // BiometricRegistration:

--- a/stytch/consumer/webauthn.go
+++ b/stytch/consumer/webauthn.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v8/stytch"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/webauthn"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/webauthn"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 type WebAuthnClient struct {

--- a/stytch/consumer/webauthn.go
+++ b/stytch/consumer/webauthn.go
@@ -18,10 +18,10 @@ import (
 )
 
 type WebAuthnClient struct {
-	C *stytch.Client
+	C stytch.Client
 }
 
-func NewWebAuthnClient(c *stytch.Client) *WebAuthnClient {
+func NewWebAuthnClient(c stytch.Client) *WebAuthnClient {
 	return &WebAuthnClient{
 		C: c,
 	}

--- a/stytch/consumer/webauthn/types.go
+++ b/stytch/consumer/webauthn/types.go
@@ -7,8 +7,8 @@ package webauthn
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v8/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v9/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `WebAuthn.Authenticate`.

--- a/stytch/stytch.go
+++ b/stytch/stytch.go
@@ -19,18 +19,31 @@ const (
 	EnvLive = config.EnvLive
 )
 
-type Client struct {
+type Client interface {
+	NewRequest(ctx context.Context, method string, path string, queryParams map[string]string, body []byte, v interface{}) error
+	RawRequest(ctx context.Context, method string, path string, queryParams map[string]string, body []byte) ([]byte, error)
+	GetConfig() *config.Config
+}
+
+type DefaultClient struct {
 	Config     *config.Config
 	HTTPClient *http.Client
 }
 
-func New(env config.Env, projectID string, secret string) *Client {
-	stytchClient := new(Client)
+func New(projectID string, secret string) *DefaultClient {
+	var detectedEnv config.Env
+	if strings.HasPrefix(projectID, "project-live-") {
+		detectedEnv = config.EnvLive
+	} else {
+		detectedEnv = config.EnvTest
+	}
+
+	stytchClient := new(DefaultClient)
 	stytchClient.Config = config.New()
 
 	stytchClient.Config.SetBasicAuthProjectID(projectID)
 	stytchClient.Config.SetBasicAuthSecret(secret)
-	stytchClient.Config.SetEnv(env)
+	stytchClient.Config.SetEnv(detectedEnv)
 
 	stytchClient.HTTPClient = &http.Client{}
 
@@ -38,7 +51,7 @@ func New(env config.Env, projectID string, secret string) *Client {
 }
 
 // newRequest is used by Call to generate and Do a http.Request
-func (c *Client) NewRequest(
+func (c *DefaultClient) NewRequest(
 	ctx context.Context,
 	method string,
 	path string,
@@ -60,7 +73,7 @@ func (c *Client) NewRequest(
 // is an error, the response body will be parsed and returned as (nil, stytcherror.Error).
 //
 // Prefer using NewRequest (which unmarshals the response JSON) unless you need the actual bytes.
-func (c *Client) RawRequest(
+func (c *DefaultClient) RawRequest(
 	ctx context.Context,
 	method string,
 	path string,
@@ -117,4 +130,8 @@ func (c *Client) RawRequest(
 	}
 	stytchErr.StatusCode = res.StatusCode
 	return nil, stytchErr
+}
+
+func (c *DefaultClient) GetConfig() *config.Config {
+	return c.Config
 }

--- a/stytch/stytch.go
+++ b/stytch/stytch.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/stytchauth/stytch-go/v8/stytch/config"
-	"github.com/stytchauth/stytch-go/v8/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v9/stytch/config"
+	"github.com/stytchauth/stytch-go/v9/stytch/stytcherror"
 )
 
 const (

--- a/stytch/stytcherror/stytcherror.go
+++ b/stytch/stytcherror/stytcherror.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/stytchauth/stytch-go/v8/stytch/config"
+	"github.com/stytchauth/stytch-go/v9/stytch/config"
 )
 
 type Error struct {


### PR DESCRIPTION
1. Imports weren't updated in last PR
2. Changes `stytch.Client` to be an interface so it can be overridden with something like `gmock`

Since this is still part of the v9 release, we're okay making this breaking change. This will bump us from 8.4.1