### PR TITLE
Use pointer types for Go optional structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It pairs well with the Stytch [Web SDK](https://www.npmjs.com/package/@stytch/st
 ## Install
 
 ```console
-$ go get github.com/stytchauth/stytch-go/v10
+$ go get github.com/stytchauth/stytch-go/v11
 ```
 
 ## Usage
@@ -35,8 +35,8 @@ Create an API client:
 import (
 	"context"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2c/stytchapi"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2c/stytchapi"
 )
 
 stytchAPIClient, err := stytchapi.NewClient(

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stytchauth/stytch-go/v10
+module github.com/stytchauth/stytch-go/v11
 
 go 1.18
 

--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b"
-	"github.com/stytchauth/stytch-go/v10/stytch/config"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b"
+	"github.com/stytchauth/stytch-go/v11/stytch/config"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer"
 )
 
 type Logger interface {

--- a/stytch/b2b/discovery.go
+++ b/stytch/b2b/discovery.go
@@ -7,7 +7,7 @@ package b2b
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch"
 )
 
 type DiscoveryClient struct {

--- a/stytch/b2b/discovery/intermediatesessions/types.go
+++ b/stytch/b2b/discovery/intermediatesessions/types.go
@@ -7,9 +7,9 @@ package intermediatesessions
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
 )
 
 // ExchangeParams: Request type for `IntermediateSessions.Exchange`.
@@ -103,10 +103,10 @@ type ExchangeResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// MemberSession: The [Session object](https://stytch.com/docs/b2b/api/session-object).
-	MemberSession sessions.MemberSession `json:"member_session,omitempty"`
+	MemberSession *sessions.MemberSession `json:"member_session,omitempty"`
 	// MFARequired: Information about the MFA requirements of the Organization and the Member's options for
 	// fulfilling MFA.
-	MFARequired mfa.MfaRequired `json:"mfa_required,omitempty"`
+	MFARequired *mfa.MfaRequired `json:"mfa_required,omitempty"`
 }
 
 type ExchangeRequestLocale string

--- a/stytch/b2b/discovery/organizations/types.go
+++ b/stytch/b2b/discovery/organizations/types.go
@@ -7,10 +7,10 @@ package organizations
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/discovery"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/discovery"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
 )
 
 // CreateParams: Request type for `Organizations.Create`.
@@ -186,12 +186,12 @@ type CreateResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// MemberSession: The [Session object](https://stytch.com/docs/b2b/api/session-object).
-	MemberSession sessions.MemberSession `json:"member_session,omitempty"`
+	MemberSession *sessions.MemberSession `json:"member_session,omitempty"`
 	// Organization: The [Organization object](https://stytch.com/docs/b2b/api/organization-object).
-	Organization organizations.Organization `json:"organization,omitempty"`
+	Organization *organizations.Organization `json:"organization,omitempty"`
 	// MFARequired: Information about the MFA requirements of the Organization and the Member's options for
 	// fulfilling MFA.
-	MFARequired mfa.MfaRequired `json:"mfa_required,omitempty"`
+	MFARequired *mfa.MfaRequired `json:"mfa_required,omitempty"`
 }
 
 // ListResponse: Response type for `Organizations.List`.

--- a/stytch/b2b/discovery/types.go
+++ b/stytch/b2b/discovery/types.go
@@ -7,8 +7,8 @@ package discovery
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
 )
 
 // DiscoveredOrganization:
@@ -18,14 +18,14 @@ type DiscoveredOrganization struct {
 	// authentication flow. See the `primary_required` and `mfa_required` fields for more details on each.
 	MemberAuthenticated bool `json:"member_authenticated,omitempty"`
 	// Organization: The [Organization object](https://stytch.com/docs/b2b/api/organization-object).
-	Organization organizations.Organization `json:"organization,omitempty"`
+	Organization *organizations.Organization `json:"organization,omitempty"`
 	// Membership: Information about the membership.
-	Membership Membership `json:"membership,omitempty"`
+	Membership *Membership `json:"membership,omitempty"`
 	// PrimaryRequired: Information about the primary authentication requirements of the Organization.
-	PrimaryRequired PrimaryRequired `json:"primary_required,omitempty"`
+	PrimaryRequired *PrimaryRequired `json:"primary_required,omitempty"`
 	// MFARequired: Information about the MFA requirements of the Organization and the Member's options for
 	// fulfilling MFA.
-	MFARequired mfa.MfaRequired `json:"mfa_required,omitempty"`
+	MFARequired *mfa.MfaRequired `json:"mfa_required,omitempty"`
 }
 
 // Membership:
@@ -36,7 +36,7 @@ type Membership struct {
 	Details map[string]any `json:"details,omitempty"`
 	// Member: The [Member object](https://stytch.com/docs/b2b/api/member-object) if one already exists, or
 	// null if one does not.
-	Member organizations.Member `json:"member,omitempty"`
+	Member *organizations.Member `json:"member,omitempty"`
 }
 
 // PrimaryRequired:

--- a/stytch/b2b/discovery_intermediatesessions.go
+++ b/stytch/b2b/discovery_intermediatesessions.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/discovery/intermediatesessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/discovery/intermediatesessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type DiscoveryIntermediateSessionsClient struct {

--- a/stytch/b2b/discovery_organizations.go
+++ b/stytch/b2b/discovery_organizations.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/discovery/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/discovery/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type DiscoveryOrganizationsClient struct {

--- a/stytch/b2b/magiclinks.go
+++ b/stytch/b2b/magiclinks.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/magiclinks"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/magiclinks"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type MagicLinksClient struct {

--- a/stytch/b2b/magiclinks/discovery/types.go
+++ b/stytch/b2b/magiclinks/discovery/types.go
@@ -7,7 +7,7 @@ package discovery
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/discovery"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/discovery"
 )
 
 // AuthenticateParams: Request type for `Discovery.Authenticate`.

--- a/stytch/b2b/magiclinks/email/types.go
+++ b/stytch/b2b/magiclinks/email/types.go
@@ -7,7 +7,7 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
 )
 
 // InviteParams: Request type for `Email.Invite`.

--- a/stytch/b2b/magiclinks/types.go
+++ b/stytch/b2b/magiclinks/types.go
@@ -7,9 +7,9 @@ package magiclinks
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
 )
 
 // AuthenticateParams: Request type for `MagicLinks.Authenticate`.
@@ -119,7 +119,7 @@ type AuthenticateResponse struct {
 	StatusCode int32 `json:"status_code,omitempty"`
 	// MFARequired: Information about the MFA requirements of the Organization and the Member's options for
 	// fulfilling MFA.
-	MFARequired mfa.MfaRequired `json:"mfa_required,omitempty"`
+	MFARequired *mfa.MfaRequired `json:"mfa_required,omitempty"`
 }
 
 type AuthenticateRequestLocale string

--- a/stytch/b2b/magiclinks_discovery.go
+++ b/stytch/b2b/magiclinks_discovery.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/magiclinks/discovery"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/magiclinks/discovery"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type MagicLinksDiscoveryClient struct {

--- a/stytch/b2b/magiclinks_email.go
+++ b/stytch/b2b/magiclinks_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/magiclinks/email"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/magiclinks/email"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type MagicLinksEmailClient struct {

--- a/stytch/b2b/magiclinks_email_discovery.go
+++ b/stytch/b2b/magiclinks_email_discovery.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/magiclinks/email/discovery"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/magiclinks/email/discovery"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type MagicLinksEmailDiscoveryClient struct {

--- a/stytch/b2b/mfa/types.go
+++ b/stytch/b2b/mfa/types.go
@@ -15,7 +15,7 @@ type MemberOptions struct {
 // MfaRequired:
 type MfaRequired struct {
 	// MemberOptions: Information about the Member's options for completing MFA.
-	MemberOptions MemberOptions `json:"member_options,omitempty"`
+	MemberOptions *MemberOptions `json:"member_options,omitempty"`
 	// SecondaryAuthInitiated: If null, indicates that no secondary authentication has been initiated. If equal
 	// to "sms_otp", indicates that the Member has a phone number, and a one time passcode has been sent to the
 	// Member's phone number. No secondary authentication will be initiated during calls to the discovery

--- a/stytch/b2b/oauth.go
+++ b/stytch/b2b/oauth.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/oauth"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/oauth"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type OAuthClient struct {

--- a/stytch/b2b/oauth/discovery/types.go
+++ b/stytch/b2b/oauth/discovery/types.go
@@ -7,7 +7,7 @@ package discovery
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/discovery"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/discovery"
 )
 
 // AuthenticateParams: Request type for `Discovery.Authenticate`.

--- a/stytch/b2b/oauth/types.go
+++ b/stytch/b2b/oauth/types.go
@@ -9,9 +9,9 @@ package oauth
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
 )
 
 // AuthenticateParams: Request type for `OAuth.Authenticate`.
@@ -127,17 +127,17 @@ type AuthenticateResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// MemberSession: The [Session object](https://stytch.com/docs/b2b/api/session-object).
-	MemberSession sessions.MemberSession `json:"member_session,omitempty"`
+	MemberSession *sessions.MemberSession `json:"member_session,omitempty"`
 	// ProviderValues: The `provider_values` object lists relevant identifiers, values, and scopes for a given
 	// OAuth provider. For example this object will include a provider's `access_token` that you can use to
 	// access the provider's API for a given user.
 	//
 	//   Note that these values will vary based on the OAuth provider in question, e.g. `id_token` is only
 	// returned by Microsoft.
-	ProviderValues ProviderValues `json:"provider_values,omitempty"`
+	ProviderValues *ProviderValues `json:"provider_values,omitempty"`
 	// MFARequired: Information about the MFA requirements of the Organization and the Member's options for
 	// fulfilling MFA.
-	MFARequired mfa.MfaRequired `json:"mfa_required,omitempty"`
+	MFARequired *mfa.MfaRequired `json:"mfa_required,omitempty"`
 }
 
 type AuthenticateRequestLocale string

--- a/stytch/b2b/oauth_discovery.go
+++ b/stytch/b2b/oauth_discovery.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/oauth/discovery"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/oauth/discovery"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type OAuthDiscoveryClient struct {

--- a/stytch/b2b/organizations.go
+++ b/stytch/b2b/organizations.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type OrganizationsClient struct {

--- a/stytch/b2b/organizations/members/types.go
+++ b/stytch/b2b/organizations/members/types.go
@@ -7,7 +7,7 @@ package members
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
 )
 
 // CreateParams: Request type for `Members.Create`.
@@ -107,7 +107,7 @@ type SearchParams struct {
 	// Query: The optional query object contains the operator, i.e. `AND` or `OR`, and the operands that will
 	// filter your results. Only an operator is required. If you include no operands, no filtering will be
 	// applied. If you include no query object, it will return all Members with no filtering applied.
-	Query organizations.SearchQuery `json:"query,omitempty"`
+	Query *organizations.SearchQuery `json:"query,omitempty"`
 }
 
 // UpdateParams: Request type for `Members.Update`.

--- a/stytch/b2b/organizations/types.go
+++ b/stytch/b2b/organizations/types.go
@@ -291,7 +291,7 @@ type SearchParams struct {
 	// Query: The optional query object contains the operator, i.e. `AND` or `OR`, and the operands that will
 	// filter your results. Only an operator is required. If you include no operands, no filtering will be
 	// applied. If you include no query object, it will return all Organizations with no filtering applied.
-	Query SearchQuery `json:"query,omitempty"`
+	Query *SearchQuery `json:"query,omitempty"`
 }
 
 // SearchQuery:

--- a/stytch/b2b/organizations_members.go
+++ b/stytch/b2b/organizations_members.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations/members"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations/members"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type OrganizationsMembersClient struct {

--- a/stytch/b2b/otp.go
+++ b/stytch/b2b/otp.go
@@ -7,7 +7,7 @@ package b2b
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch"
 )
 
 type OTPsClient struct {

--- a/stytch/b2b/otp/sms/types.go
+++ b/stytch/b2b/otp/sms/types.go
@@ -7,8 +7,8 @@ package sms
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
 )
 
 // AuthenticateParams: Request type for `Sms.Authenticate`.
@@ -117,7 +117,7 @@ type AuthenticateResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// MemberSession: The [Session object](https://stytch.com/docs/b2b/api/session-object).
-	MemberSession sessions.MemberSession `json:"member_session,omitempty"`
+	MemberSession *sessions.MemberSession `json:"member_session,omitempty"`
 }
 
 // SendResponse: Response type for `Sms.Send`.

--- a/stytch/b2b/otp_sms.go
+++ b/stytch/b2b/otp_sms.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/otp/sms"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/otp/sms"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type OTPsSmsClient struct {

--- a/stytch/b2b/passwords.go
+++ b/stytch/b2b/passwords.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/passwords"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/passwords"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type PasswordsClient struct {

--- a/stytch/b2b/passwords/email/types.go
+++ b/stytch/b2b/passwords/email/types.go
@@ -7,9 +7,9 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
 )
 
 // ResetParams: Request type for `Email.Reset`.
@@ -154,10 +154,10 @@ type ResetResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// MemberSession: The [Session object](https://stytch.com/docs/b2b/api/session-object).
-	MemberSession sessions.MemberSession `json:"member_session,omitempty"`
+	MemberSession *sessions.MemberSession `json:"member_session,omitempty"`
 	// MFARequired: Information about the MFA requirements of the Organization and the Member's options for
 	// fulfilling MFA.
-	MFARequired mfa.MfaRequired `json:"mfa_required,omitempty"`
+	MFARequired *mfa.MfaRequired `json:"mfa_required,omitempty"`
 }
 
 // ResetStartResponse: Response type for `Email.ResetStart`.

--- a/stytch/b2b/passwords/existingpassword/types.go
+++ b/stytch/b2b/passwords/existingpassword/types.go
@@ -7,9 +7,9 @@ package existingpassword
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
 )
 
 // ResetParams: Request type for `ExistingPassword.Reset`.
@@ -99,10 +99,10 @@ type ResetResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// MemberSession: The [Session object](https://stytch.com/docs/b2b/api/session-object).
-	MemberSession sessions.MemberSession `json:"member_session,omitempty"`
+	MemberSession *sessions.MemberSession `json:"member_session,omitempty"`
 	// MFARequired: Information about the MFA requirements of the Organization and the Member's options for
 	// fulfilling MFA.
-	MFARequired mfa.MfaRequired `json:"mfa_required,omitempty"`
+	MFARequired *mfa.MfaRequired `json:"mfa_required,omitempty"`
 }
 
 type ResetRequestLocale string

--- a/stytch/b2b/passwords/session/types.go
+++ b/stytch/b2b/passwords/session/types.go
@@ -7,8 +7,8 @@ package session
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
 )
 
 // ResetParams: Request type for `Sessions.Reset`.
@@ -42,5 +42,5 @@ type ResetResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// MemberSession: The [Session object](https://stytch.com/docs/b2b/api/session-object).
-	MemberSession sessions.MemberSession `json:"member_session,omitempty"`
+	MemberSession *sessions.MemberSession `json:"member_session,omitempty"`
 }

--- a/stytch/b2b/passwords/types.go
+++ b/stytch/b2b/passwords/types.go
@@ -7,10 +7,10 @@ package passwords
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/passwords"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/passwords"
 )
 
 // AuthenticateParams: Request type for `Passwords.Authenticate`.
@@ -99,17 +99,17 @@ type MigrateParams struct {
 	// critical to perform operations on an Organization, so be sure to preserve this value.
 	OrganizationID string `json:"organization_id,omitempty"`
 	// Md5Config: Optional parameters for MD-5 hash types.
-	Md5Config passwords.MD5Config `json:"md_5_config,omitempty"`
+	Md5Config *passwords.MD5Config `json:"md_5_config,omitempty"`
 	// Argon2Config: Required parameters if the argon2 hex form, as opposed to the encoded form, is supplied.
-	Argon2Config passwords.Argon2Config `json:"argon_2_config,omitempty"`
+	Argon2Config *passwords.Argon2Config `json:"argon_2_config,omitempty"`
 	// Sha1Config: Optional parameters for SHA-1 hash types.
-	Sha1Config passwords.SHA1Config `json:"sha_1_config,omitempty"`
+	Sha1Config *passwords.SHA1Config `json:"sha_1_config,omitempty"`
 	// ScryptConfig: Required parameters if the scrypt is not provided in a **PHC encoded form**.
-	ScryptConfig passwords.ScryptConfig `json:"scrypt_config,omitempty"`
+	ScryptConfig *passwords.ScryptConfig `json:"scrypt_config,omitempty"`
 	// Pbkdf2Config: Required additional parameters for PBKDF2 hash keys. Note that we use the SHA-256 by
 	// default, please contact [support@stytch.com](mailto:support@stytch.com) if you use another hashing
 	// function.
-	Pbkdf2Config passwords.PBKDF2Config `json:"pbkdf_2_config,omitempty"`
+	Pbkdf2Config *passwords.PBKDF2Config `json:"pbkdf_2_config,omitempty"`
 	// Name: The name of the Member. Each field in the name object is optional.
 	Name string `json:"name,omitempty"`
 	// TrustedMetadata: An arbitrary JSON object for storing application-specific data or
@@ -177,10 +177,10 @@ type AuthenticateResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// MemberSession: The [Session object](https://stytch.com/docs/b2b/api/session-object).
-	MemberSession sessions.MemberSession `json:"member_session,omitempty"`
+	MemberSession *sessions.MemberSession `json:"member_session,omitempty"`
 	// MFARequired: Information about the MFA requirements of the Organization and the Member's options for
 	// fulfilling MFA.
-	MFARequired mfa.MfaRequired `json:"mfa_required,omitempty"`
+	MFARequired *mfa.MfaRequired `json:"mfa_required,omitempty"`
 }
 
 // MigrateResponse: Response type for `Passwords.Migrate`.
@@ -240,10 +240,10 @@ type StrengthCheckResponse struct {
 	StatusCode int32 `json:"status_code,omitempty"`
 	// LudsFeedback: Feedback for how to improve the password's strength using
 	// [luds](https://stytch.com/docs/passwords#strength-requirements).
-	LudsFeedback LudsFeedback `json:"luds_feedback,omitempty"`
+	LudsFeedback *LudsFeedback `json:"luds_feedback,omitempty"`
 	// ZxcvbnFeedback: Feedback for how to improve the password's strength using
 	// [zxcvbn](https://stytch.com/docs/passwords#strength-requirements).
-	ZxcvbnFeedback ZxcvbnFeedback `json:"zxcvbn_feedback,omitempty"`
+	ZxcvbnFeedback *ZxcvbnFeedback `json:"zxcvbn_feedback,omitempty"`
 }
 
 type AuthenticateRequestLocale string

--- a/stytch/b2b/passwords_email.go
+++ b/stytch/b2b/passwords_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/passwords/email"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/passwords/email"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type PasswordsEmailClient struct {

--- a/stytch/b2b/passwords_existingpassword.go
+++ b/stytch/b2b/passwords_existingpassword.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/passwords/existingpassword"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/passwords/existingpassword"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type PasswordsExistingPasswordClient struct {

--- a/stytch/b2b/passwords_session.go
+++ b/stytch/b2b/passwords_session.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/passwords/session"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/passwords/session"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type PasswordsSessionsClient struct {

--- a/stytch/b2b/sessions.go
+++ b/stytch/b2b/sessions.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type SessionsClient struct {

--- a/stytch/b2b/sessions/types.go
+++ b/stytch/b2b/sessions/types.go
@@ -9,9 +9,9 @@ package sessions
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
 )
 
 // AuthenticateParams: Request type for `Sessions.Authenticate`.
@@ -210,7 +210,7 @@ type ExchangeResponse struct {
 	StatusCode int32 `json:"status_code,omitempty"`
 	// MFARequired: Information about the MFA requirements of the Organization and the Member's options for
 	// fulfilling MFA.
-	MFARequired mfa.MfaRequired `json:"mfa_required,omitempty"`
+	MFARequired *mfa.MfaRequired `json:"mfa_required,omitempty"`
 }
 
 // GetJWKSResponse: Response type for `Sessions.GetJWKS`.

--- a/stytch/b2b/sso.go
+++ b/stytch/b2b/sso.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sso"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sso"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type SSOClient struct {

--- a/stytch/b2b/sso/oidc/types.go
+++ b/stytch/b2b/sso/oidc/types.go
@@ -7,7 +7,7 @@ package oidc
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sso"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sso"
 )
 
 // CreateConnectionParams: Request type for `OIDC.CreateConnection`.
@@ -64,7 +64,7 @@ type CreateConnectionResponse struct {
 	// Connection: The `OIDC Connection` object affected by this API call. See the
 	// [OIDC Connection Object](https://stytch.com/docs/b2b/api/oidc-connection-object) for complete response
 	// field details.
-	Connection sso.OIDCConnection `json:"connection,omitempty"`
+	Connection *sso.OIDCConnection `json:"connection,omitempty"`
 }
 
 // UpdateConnectionResponse: Response type for `OIDC.UpdateConnection`.
@@ -80,7 +80,7 @@ type UpdateConnectionResponse struct {
 	// Connection: The `OIDC Connection` object affected by this API call. See the
 	// [OIDC Connection Object](https://stytch.com/docs/b2b/api/oidc-connection-object) for complete response
 	// field details.
-	Connection sso.OIDCConnection `json:"connection,omitempty"`
+	Connection *sso.OIDCConnection `json:"connection,omitempty"`
 	// Warning: If it is not possible to resolve the well-known metadata document from the OIDC issuer, this
 	// field will explain what went wrong if the request is successful otherwise. In other words, even if the
 	// overall request succeeds, there could be relevant warnings related to the connection update.

--- a/stytch/b2b/sso/saml/types.go
+++ b/stytch/b2b/sso/saml/types.go
@@ -7,7 +7,7 @@ package saml
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sso"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sso"
 )
 
 // CreateConnectionParams: Request type for `SAML.CreateConnection`.
@@ -66,7 +66,7 @@ type CreateConnectionResponse struct {
 	// Connection: The `SAML Connection` object affected by this API call. See the
 	// [SAML Connection Object](https://stytch.com/docs/b2b/api/saml-connection-object) for complete response
 	// field details.
-	Connection sso.SAMLConnection `json:"connection,omitempty"`
+	Connection *sso.SAMLConnection `json:"connection,omitempty"`
 }
 
 // DeleteVerificationCertificateResponse: Response type for `SAML.DeleteVerificationCertificate`.
@@ -96,5 +96,5 @@ type UpdateConnectionResponse struct {
 	// Connection: The `SAML Connection` object affected by this API call. See the
 	// [SAML Connection Object](https://stytch.com/docs/b2b/api/saml-connection-object) for complete response
 	// field details.
-	Connection sso.SAMLConnection `json:"connection,omitempty"`
+	Connection *sso.SAMLConnection `json:"connection,omitempty"`
 }

--- a/stytch/b2b/sso/types.go
+++ b/stytch/b2b/sso/types.go
@@ -9,9 +9,9 @@ package sso
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
 )
 
 // AuthenticateParams: Request type for `SSO.Authenticate`.
@@ -154,10 +154,10 @@ type AuthenticateResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// MemberSession: The [Session object](https://stytch.com/docs/b2b/api/session-object).
-	MemberSession sessions.MemberSession `json:"member_session,omitempty"`
+	MemberSession *sessions.MemberSession `json:"member_session,omitempty"`
 	// MFARequired: Information about the MFA requirements of the Organization and the Member's options for
 	// fulfilling MFA.
-	MFARequired mfa.MfaRequired `json:"mfa_required,omitempty"`
+	MFARequired *mfa.MfaRequired `json:"mfa_required,omitempty"`
 }
 
 // DeleteConnectionResponse: Response type for `SSO.DeleteConnection`.

--- a/stytch/b2b/sso_oidc.go
+++ b/stytch/b2b/sso_oidc.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sso/oidc"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sso/oidc"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type SSOOIDCClient struct {

--- a/stytch/b2b/sso_saml.go
+++ b/stytch/b2b/sso_saml.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/b2b/sso/saml"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sso/saml"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type SSOSAMLClient struct {

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "10.2.1"
+const APIVersion = "11.0.0"

--- a/stytch/consumer/cryptowallets.go
+++ b/stytch/consumer/cryptowallets.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/cryptowallets"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/cryptowallets"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type CryptoWalletsClient struct {

--- a/stytch/consumer/cryptowallets/types.go
+++ b/stytch/consumer/cryptowallets/types.go
@@ -7,8 +7,8 @@ package cryptowallets
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `CryptoWallets.Authenticate`.
@@ -88,7 +88,7 @@ type AuthenticateResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	Session sessions.Session `json:"session,omitempty"`
+	Session *sessions.Session `json:"session,omitempty"`
 }
 
 // AuthenticateStartResponse: Response type for `CryptoWallets.AuthenticateStart`.

--- a/stytch/consumer/m2m.go
+++ b/stytch/consumer/m2m.go
@@ -18,10 +18,10 @@ import (
 
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/config"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/m2m"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/config"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type M2MClient struct {
@@ -40,9 +40,9 @@ func NewM2MClient(c stytch.Client) *M2MClient {
 // MANUAL(Token)(SERVICE_METHOD)
 // ADDIMPORT: "context"
 // ADDIMPORT: "fmt"
-// ADDIMPORT: "github.com/stytchauth/stytch-go/v10/stytch/config"
-// ADDIMPORT: "github.com/stytchauth/stytch-go/v10/stytch/consumer/m2m"
-// ADDIMPORT: "github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/config"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 // ADDIMPORT: "io"
 // ADDIMPORT: "net/http"
 // ADDIMPORT: "net/url"

--- a/stytch/consumer/m2m/clients/secrets/types.go
+++ b/stytch/consumer/m2m/clients/secrets/types.go
@@ -7,7 +7,7 @@ package secrets
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/m2m"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m"
 )
 
 // RotateCancelParams: Request type for `Secrets.RotateCancel`.

--- a/stytch/consumer/m2m/clients/types.go
+++ b/stytch/consumer/m2m/clients/types.go
@@ -7,7 +7,7 @@ package clients
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/m2m"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m"
 )
 
 // CreateParams: Request type for `Clients.Create`.
@@ -59,7 +59,7 @@ type SearchParams struct {
 	// Query: The optional query object contains the operator, i.e. `AND` or `OR`, and the operands that will
 	// filter your results. Only an operator is required. If you include no operands, no filtering will be
 	// applied. If you include no query object, it will return all results with no filtering applied.
-	Query m2m.M2MSearchQuery `json:"query,omitempty"`
+	Query *m2m.M2MSearchQuery `json:"query,omitempty"`
 }
 
 // UpdateParams: Request type for `Clients.Update`.

--- a/stytch/consumer/m2m_clients.go
+++ b/stytch/consumer/m2m_clients.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/m2m/clients"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m/clients"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type M2MClientsClient struct {

--- a/stytch/consumer/m2m_clients_secrets.go
+++ b/stytch/consumer/m2m_clients_secrets.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/m2m/clients/secrets"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m/clients/secrets"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type M2MClientsSecretsClient struct {
@@ -28,10 +28,10 @@ func NewM2MClientsSecretsClient(c stytch.Client) *M2MClientsSecretsClient {
 
 // RotateStart: Initiate the rotation of an M2M client secret. After this endpoint is called, both the
 // client's `client_secret` and `next_client_secret` will be valid. To complete the secret rotation flow,
-// update all usages of `client_secret` to `next_client_secret` and call
-// the[Rotate Secret Endpoint](https://stytch.com/docs/b2b/api/m2m-rotate-secret)[Rotate Secret Endpoint](https://stytch.com/docs/api/m2m-rotate-secret) to complete the flow.
-// Secret rotation can be cancelled using
-// the[Rotate Cancel Endpoint](https://stytch.com/docs/b2b/api/m2m-rotate-secret-cancel)[Rotate Cancel Endpoint](https://stytch.com/docs/api/m2m-rotate-secret-cancel).
+// update all usages of `client_secret` to `next_client_secret` and call the
+// [Rotate Secret Endpoint](https://stytch.com/docs/b2b/api/m2m-rotate-secret)[Rotate Secret Endpoint](https://stytch.com/docs/api/m2m-rotate-secret) to complete the flow.
+// Secret rotation can be cancelled using the
+// [Rotate Cancel Endpoint](https://stytch.com/docs/b2b/api/m2m-rotate-secret-cancel)[Rotate Cancel Endpoint](https://stytch.com/docs/api/m2m-rotate-secret-cancel).
 //
 // **Important:** This is the only time you will be able to view the generated `next_client_secret` in the
 // API response. Stytch stores a hash of the `next_client_secret` and cannot recover the value if lost. Be
@@ -62,8 +62,9 @@ func (c *M2MClientsSecretsClient) RotateStart(
 	return &retVal, err
 }
 
-// RotateCancel: Cancel the rotation of an M2M client secret started with
-// the[Start Secret Rotation Endpoint](https://stytch.com/docs/b2b/api/m2m-rotate-secret-start)[Start Secret Rotation Endpoint](https://stytch.com/docs/api/m2m-rotate-secret-start).
+// RotateCancel: Cancel the rotation of an M2M client secret started with the
+// [Start Secret Rotation Endpoint](https://stytch.com/docs/b2b/api/m2m-rotate-secret-start)
+// [Start Secret Rotation Endpoint](https://stytch.com/docs/api/m2m-rotate-secret-start).
 // After this endpoint is called, the client's `next_client_secret` is discarded and only the original
 // `client_secret` will be valid.
 func (c *M2MClientsSecretsClient) RotateCancel(
@@ -91,8 +92,9 @@ func (c *M2MClientsSecretsClient) RotateCancel(
 	return &retVal, err
 }
 
-// Rotate: Complete the rotation of an M2M client secret started with
-// the[Start Secret Rotation Endpoint](https://stytch.com/docs/b2b/api/m2m-rotate-secret-start)[Start Secret Rotation Endpoint](https://stytch.com/docs/api/m2m-rotate-secret-start).
+// Rotate: Complete the rotation of an M2M client secret started with the
+// [Start Secret Rotation Endpoint](https://stytch.com/docs/b2b/api/m2m-rotate-secret-start)
+// [Start Secret Rotation Endpoint](https://stytch.com/docs/api/m2m-rotate-secret-start).
 // After this endpoint is called, the client's `next_client_secret` becomes its `client_secret` and the
 // previous `client_secret` will no longer be valid.
 func (c *M2MClientsSecretsClient) Rotate(

--- a/stytch/consumer/m2m_test.go
+++ b/stytch/consumer/m2m_test.go
@@ -9,16 +9,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/config"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/m2m"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/config"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m"
 )
 
 func TestM2MClient_Token(t *testing.T) {

--- a/stytch/consumer/magiclinks.go
+++ b/stytch/consumer/magiclinks.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type MagicLinksClient struct {

--- a/stytch/consumer/magiclinks/email/types.go
+++ b/stytch/consumer/magiclinks/email/types.go
@@ -7,8 +7,8 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 // InviteParams: Request type for `Email.Invite`.
@@ -20,9 +20,9 @@ type InviteParams struct {
 	// Magic links - Invite.
 	InviteTemplateID string `json:"invite_template_id,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// Name: The name of the user. Each field in the name object is optional.
-	Name users.Name `json:"name,omitempty"`
+	Name *users.Name `json:"name,omitempty"`
 	// InviteMagicLinkURL: The URL the end user clicks from the Email Magic Link. This should be a URL that
 	// your app receives and parses and subsequently sends an API request to authenticate the Magic Link and
 	// log in the User. If this value is not passed, the default invite redirect URL that you set in your
@@ -72,7 +72,7 @@ type LoginOrCreateParams struct {
 	// Magic links - Sign-up.
 	SignupTemplateID string `json:"signup_template_id,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// CreateUserAsPending: Flag for whether or not to save a user as pending vs active in Stytch. Defaults to
 	// false.
 	//         If true, users will be saved with status pending in Stytch's backend until authenticated.
@@ -111,7 +111,7 @@ type SendParams struct {
 	// Magic links - Login.
 	LoginTemplateID string `json:"login_template_id,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// LoginMagicLinkURL: The URL the end user clicks from the login Email Magic Link. This should be a URL
 	// that your app receives and parses and subsequently send an API request to authenticate the Magic Link
 	// and log in the User. If this value is not passed, the default login redirect URL that you set in your

--- a/stytch/consumer/magiclinks/types.go
+++ b/stytch/consumer/magiclinks/types.go
@@ -7,9 +7,9 @@ package magiclinks
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `MagicLinks.Authenticate`.
@@ -17,9 +17,9 @@ type AuthenticateParams struct {
 	// Token: The token to authenticate.
 	Token string `json:"token,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// Options: Specify optional security settings.
-	Options Options `json:"options,omitempty"`
+	Options *Options `json:"options,omitempty"`
 	// SessionToken: The `session_token` associated with a User's existing Session.
 	SessionToken string `json:"session_token,omitempty"`
 	// SessionDurationMinutes: Set the session lifetime to be this many minutes from now. This will start a new
@@ -58,7 +58,7 @@ type CreateParams struct {
 	// hour. The minimum expiration is 5 minutes and the maximum is 7 days (10080 mins).
 	ExpirationMinutes int32 `json:"expiration_minutes,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 }
 
 // Options:
@@ -101,7 +101,7 @@ type AuthenticateResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	Session sessions.Session `json:"session,omitempty"`
+	Session *sessions.Session `json:"session,omitempty"`
 }
 
 // CreateResponse: Response type for `MagicLinks.Create`.

--- a/stytch/consumer/magiclinks_email.go
+++ b/stytch/consumer/magiclinks_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/magiclinks/email"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/magiclinks/email"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type MagicLinksEmailClient struct {

--- a/stytch/consumer/oauth.go
+++ b/stytch/consumer/oauth.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/oauth"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/oauth"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type OAuthClient struct {

--- a/stytch/consumer/oauth/types.go
+++ b/stytch/consumer/oauth/types.go
@@ -9,8 +9,8 @@ package oauth
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 // AttachParams: Request type for `OAuth.Attach`.
@@ -142,5 +142,5 @@ type AuthenticateResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	UserSession sessions.Session `json:"user_session,omitempty"`
+	UserSession *sessions.Session `json:"user_session,omitempty"`
 }

--- a/stytch/consumer/otp.go
+++ b/stytch/consumer/otp.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/otp"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/otp"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type OTPsClient struct {

--- a/stytch/consumer/otp/email/types.go
+++ b/stytch/consumer/otp/email/types.go
@@ -7,7 +7,7 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
 )
 
 // LoginOrCreateParams: Request type for `Email.LoginOrCreate`.
@@ -19,7 +19,7 @@ type LoginOrCreateParams struct {
 	// minute and the maximum is 10 minutes. The default expiration is 2 minutes.
 	ExpirationMinutes int32 `json:"expiration_minutes,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// CreateUserAsPending: Flag for whether or not to save a user as pending vs active in Stytch. Defaults to
 	// false.
 	//         If true, users will be saved with status pending in Stytch's backend until authenticated.
@@ -57,7 +57,7 @@ type SendParams struct {
 	// minute and the maximum is 10 minutes. The default expiration is 2 minutes.
 	ExpirationMinutes int32 `json:"expiration_minutes,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// Locale: Used to determine which language to use when sending the user this delivery method. Parameter is
 	// a [IETF BCP 47 language tag](https://www.w3.org/International/articles/language-tags/), e.g. `"en"`.
 	//

--- a/stytch/consumer/otp/sms/types.go
+++ b/stytch/consumer/otp/sms/types.go
@@ -7,7 +7,7 @@ package sms
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
 )
 
 // LoginOrCreateParams: Request type for `Sms.LoginOrCreate`.
@@ -20,7 +20,7 @@ type LoginOrCreateParams struct {
 	// minute and the maximum is 10 minutes. The default expiration is 2 minutes.
 	ExpirationMinutes int32 `json:"expiration_minutes,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// CreateUserAsPending: Flag for whether or not to save a user as pending vs active in Stytch. Defaults to
 	// false.
 	//         If true, users will be saved with status pending in Stytch's backend until authenticated.
@@ -51,7 +51,7 @@ type SendParams struct {
 	// minute and the maximum is 10 minutes. The default expiration is 2 minutes.
 	ExpirationMinutes int32 `json:"expiration_minutes,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// Locale: Used to determine which language to use when sending the user this delivery method. Parameter is
 	// a [IETF BCP 47 language tag](https://www.w3.org/International/articles/language-tags/), e.g. `"en"`.
 	//

--- a/stytch/consumer/otp/types.go
+++ b/stytch/consumer/otp/types.go
@@ -7,10 +7,10 @@ package otp
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `OTPs.Authenticate`.
@@ -20,9 +20,9 @@ type AuthenticateParams struct {
 	// Code: The code to authenticate.
 	Code string `json:"code,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// Options: Specify optional security settings.
-	Options magiclinks.Options `json:"options,omitempty"`
+	Options *magiclinks.Options `json:"options,omitempty"`
 	// SessionToken: The `session_token` associated with a User's existing Session.
 	SessionToken string `json:"session_token,omitempty"`
 	// SessionDurationMinutes: Set the session lifetime to be this many minutes from now. This will start a new
@@ -80,5 +80,5 @@ type AuthenticateResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	Session sessions.Session `json:"session,omitempty"`
+	Session *sessions.Session `json:"session,omitempty"`
 }

--- a/stytch/consumer/otp/whatsapp/types.go
+++ b/stytch/consumer/otp/whatsapp/types.go
@@ -7,7 +7,7 @@ package whatsapp
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
 )
 
 // LoginOrCreateParams: Request type for `Whatsapp.LoginOrCreate`.
@@ -20,7 +20,7 @@ type LoginOrCreateParams struct {
 	// minute and the maximum is 10 minutes. The default expiration is 2 minutes.
 	ExpirationMinutes int32 `json:"expiration_minutes,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// CreateUserAsPending: Flag for whether or not to save a user as pending vs active in Stytch. Defaults to
 	// false.
 	//         If true, users will be saved with status pending in Stytch's backend until authenticated.
@@ -51,7 +51,7 @@ type SendParams struct {
 	// minute and the maximum is 10 minutes. The default expiration is 2 minutes.
 	ExpirationMinutes int32 `json:"expiration_minutes,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// Locale: Used to determine which language to use when sending the user this delivery method. Parameter is
 	// a [IETF BCP 47 language tag](https://www.w3.org/International/articles/language-tags/), e.g. `"en"`.
 	//

--- a/stytch/consumer/otp_email.go
+++ b/stytch/consumer/otp_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/otp/email"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/otp/email"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type OTPsEmailClient struct {

--- a/stytch/consumer/otp_sms.go
+++ b/stytch/consumer/otp_sms.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/otp/sms"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/otp/sms"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type OTPsSmsClient struct {

--- a/stytch/consumer/otp_whatsapp.go
+++ b/stytch/consumer/otp_whatsapp.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/otp/whatsapp"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/otp/whatsapp"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type OTPsWhatsappClient struct {

--- a/stytch/consumer/passwords.go
+++ b/stytch/consumer/passwords.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/passwords"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/passwords"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type PasswordsClient struct {

--- a/stytch/consumer/passwords/email/types.go
+++ b/stytch/consumer/passwords/email/types.go
@@ -7,10 +7,10 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 // ResetParams: Request type for `Email.Reset`.
@@ -48,9 +48,9 @@ type ResetParams struct {
 	// ignored. Total custom claims size cannot exceed four kilobytes.
 	SessionCustomClaims map[string]any `json:"session_custom_claims,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// Options: Specify optional security settings.
-	Options magiclinks.Options `json:"options,omitempty"`
+	Options *magiclinks.Options `json:"options,omitempty"`
 }
 
 // ResetStartParams: Request type for `Email.ResetStart`.
@@ -74,7 +74,7 @@ type ResetStartParams struct {
 	// starts and ends on the same device.
 	CodeChallenge string `json:"code_challenge,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// LoginRedirectURL: The URL Stytch redirects to after the OAuth flow is completed for a user that already
 	// exists. This URL should be a route in your application which will run `oauth.authenticate` (see below)
 	// and finish the login.
@@ -123,7 +123,7 @@ type ResetResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	Session sessions.Session `json:"session,omitempty"`
+	Session *sessions.Session `json:"session,omitempty"`
 }
 
 // ResetStartResponse: Response type for `Email.ResetStart`.

--- a/stytch/consumer/passwords/existingpassword/types.go
+++ b/stytch/consumer/passwords/existingpassword/types.go
@@ -7,8 +7,8 @@ package existingpassword
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 // ResetParams: Request type for `ExistingPassword.Reset`.
@@ -70,5 +70,5 @@ type ResetResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	Session sessions.Session `json:"session,omitempty"`
+	Session *sessions.Session `json:"session,omitempty"`
 }

--- a/stytch/consumer/passwords/session/types.go
+++ b/stytch/consumer/passwords/session/types.go
@@ -7,8 +7,8 @@ package session
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 // ResetParams: Request type for `Sessions.Reset`.
@@ -41,5 +41,5 @@ type ResetResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	Session sessions.Session `json:"session,omitempty"`
+	Session *sessions.Session `json:"session,omitempty"`
 }

--- a/stytch/consumer/passwords/types.go
+++ b/stytch/consumer/passwords/types.go
@@ -7,8 +7,8 @@ package passwords
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 // Argon2Config:
@@ -95,7 +95,7 @@ type CreateParams struct {
 	// [Metadata](https://stytch.com/docs/api/metadata) reference for complete field behavior details.
 	UntrustedMetadata map[string]any `json:"untrusted_metadata,omitempty"`
 	// Name: The name of the user. Each field in the name object is optional.
-	Name users.Name `json:"name,omitempty"`
+	Name *users.Name `json:"name,omitempty"`
 }
 
 // Feedback:
@@ -109,7 +109,7 @@ type Feedback struct {
 	// LudsRequirements: Contains which LUDS properties are fulfilled by the password and which are missing to
 	// convert an invalid password into a valid one. You'll use these fields to provide feedback to the user on
 	// how to improve the password.
-	LudsRequirements LUDSRequirements `json:"luds_requirements,omitempty"`
+	LudsRequirements *LUDSRequirements `json:"luds_requirements,omitempty"`
 }
 
 // LUDSRequirements:
@@ -150,16 +150,16 @@ type MigrateParams struct {
 	// `sha_1`, and `pbkdf_2` are supported.
 	HashType MigrateRequestHashType `json:"hash_type,omitempty"`
 	// Md5Config: Optional parameters for MD-5 hash types.
-	Md5Config MD5Config `json:"md_5_config,omitempty"`
+	Md5Config *MD5Config `json:"md_5_config,omitempty"`
 	// Argon2Config: Required parameters if the argon2 hex form, as opposed to the encoded form, is supplied.
-	Argon2Config Argon2Config `json:"argon_2_config,omitempty"`
+	Argon2Config *Argon2Config `json:"argon_2_config,omitempty"`
 	// Sha1Config: Optional parameters for SHA-1 hash types.
-	Sha1Config SHA1Config `json:"sha_1_config,omitempty"`
+	Sha1Config *SHA1Config `json:"sha_1_config,omitempty"`
 	// ScryptConfig: Required parameters if the scrypt is not provided in a
 	// [PHC encoded form](https://github.com/P-H-C/phc-string-format/blob/master/phc-sf-spec.md#phc-string-format).
-	ScryptConfig ScryptConfig `json:"scrypt_config,omitempty"`
+	ScryptConfig *ScryptConfig `json:"scrypt_config,omitempty"`
 	// Pbkdf2Config: Required additional parameters for PBKDF2 hash keys.
-	Pbkdf2Config PBKDF2Config `json:"pbkdf_2_config,omitempty"`
+	Pbkdf2Config *PBKDF2Config `json:"pbkdf_2_config,omitempty"`
 	// TrustedMetadata: The `trusted_metadata` field contains an arbitrary JSON object of application-specific
 	// data. See the [Metadata](https://stytch.com/docs/api/metadata) reference for complete field behavior
 	// details.
@@ -170,7 +170,7 @@ type MigrateParams struct {
 	// [Metadata](https://stytch.com/docs/api/metadata) reference for complete field behavior details.
 	UntrustedMetadata map[string]any `json:"untrusted_metadata,omitempty"`
 	// Name: The name of the user. Each field in the name object is optional.
-	Name users.Name `json:"name,omitempty"`
+	Name *users.Name `json:"name,omitempty"`
 }
 
 // PBKDF2Config:
@@ -240,7 +240,7 @@ type AuthenticateResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	Session sessions.Session `json:"session,omitempty"`
+	Session *sessions.Session `json:"session,omitempty"`
 }
 
 // CreateResponse: Response type for `Passwords.Create`.
@@ -269,7 +269,7 @@ type CreateResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	Session sessions.Session `json:"session,omitempty"`
+	Session *sessions.Session `json:"session,omitempty"`
 }
 
 // MigrateResponse: Response type for `Passwords.Migrate`.
@@ -324,7 +324,7 @@ type StrengthCheckResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// Feedback for how to improve the password's strength [HaveIBeenPwned](https://haveibeenpwned.com/).
-	Feedback Feedback `json:"feedback,omitempty"`
+	Feedback *Feedback `json:"feedback,omitempty"`
 }
 
 type MigrateRequestHashType string

--- a/stytch/consumer/passwords_email.go
+++ b/stytch/consumer/passwords_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/passwords/email"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/passwords/email"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type PasswordsEmailClient struct {

--- a/stytch/consumer/passwords_existingpassword.go
+++ b/stytch/consumer/passwords_existingpassword.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/passwords/existingpassword"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/passwords/existingpassword"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type PasswordsExistingPasswordClient struct {

--- a/stytch/consumer/passwords_session.go
+++ b/stytch/consumer/passwords_session.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/passwords/session"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/passwords/session"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type PasswordsSessionsClient struct {

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -15,9 +15,9 @@ import (
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type SessionsClient struct {
@@ -290,7 +290,7 @@ func marshalJWTIntoSession(claims sessions.Claims) (*sessions.Session, error) {
 		StartedAt:             &started,
 		LastAccessedAt:        &accessed,
 		ExpiresAt:             &expires,
-		Attributes:            claims.StytchSession.Attributes,
+		Attributes:            &claims.StytchSession.Attributes,
 		AuthenticationFactors: claims.StytchSession.AuthenticationFactors,
 	}, nil
 }

--- a/stytch/consumer/sessions/types.go
+++ b/stytch/consumer/sessions/types.go
@@ -8,12 +8,11 @@ package sessions
 
 import (
 	"errors"
-	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 type AmazonOAuthFactor struct {
@@ -54,39 +53,39 @@ type AuthenticationFactor struct {
 	LastAuthenticatedAt       *time.Time                         `json:"last_authenticated_at,omitempty"`
 	CreatedAt                 *time.Time                         `json:"created_at,omitempty"`
 	UpdatedAt                 *time.Time                         `json:"updated_at,omitempty"`
-	EmailFactor               EmailFactor                        `json:"email_factor,omitempty"`
-	PhoneNumberFactor         PhoneNumberFactor                  `json:"phone_number_factor,omitempty"`
-	GoogleOAuthFactor         GoogleOAuthFactor                  `json:"google_oauth_factor,omitempty"`
-	MicrosoftOAuthFactor      MicrosoftOAuthFactor               `json:"microsoft_oauth_factor,omitempty"`
-	AppleOAuthFactor          AppleOAuthFactor                   `json:"apple_oauth_factor,omitempty"`
-	WebAuthnFactor            WebAuthnFactor                     `json:"webauthn_factor,omitempty"`
-	AuthenticatorAppFactor    AuthenticatorAppFactor             `json:"authenticator_app_factor,omitempty"`
-	GithubOAuthFactor         GithubOAuthFactor                  `json:"github_oauth_factor,omitempty"`
-	RecoveryCodeFactor        RecoveryCodeFactor                 `json:"recovery_code_factor,omitempty"`
-	FacebookOAuthFactor       FacebookOAuthFactor                `json:"facebook_oauth_factor,omitempty"`
-	CryptoWalletFactor        CryptoWalletFactor                 `json:"crypto_wallet_factor,omitempty"`
-	AmazonOAuthFactor         AmazonOAuthFactor                  `json:"amazon_oauth_factor,omitempty"`
-	BitbucketOAuthFactor      BitbucketOAuthFactor               `json:"bitbucket_oauth_factor,omitempty"`
-	CoinbaseOAuthFactor       CoinbaseOAuthFactor                `json:"coinbase_oauth_factor,omitempty"`
-	DiscordOAuthFactor        DiscordOAuthFactor                 `json:"discord_oauth_factor,omitempty"`
-	FigmaOAuthFactor          FigmaOAuthFactor                   `json:"figma_oauth_factor,omitempty"`
-	GitLabOAuthFactor         GitLabOAuthFactor                  `json:"git_lab_oauth_factor,omitempty"`
-	InstagramOAuthFactor      InstagramOAuthFactor               `json:"instagram_oauth_factor,omitempty"`
-	LinkedInOAuthFactor       LinkedInOAuthFactor                `json:"linked_in_oauth_factor,omitempty"`
-	ShopifyOAuthFactor        ShopifyOAuthFactor                 `json:"shopify_oauth_factor,omitempty"`
-	SlackOAuthFactor          SlackOAuthFactor                   `json:"slack_oauth_factor,omitempty"`
-	SnapchatOAuthFactor       SnapchatOAuthFactor                `json:"snapchat_oauth_factor,omitempty"`
-	SpotifyOAuthFactor        SpotifyOAuthFactor                 `json:"spotify_oauth_factor,omitempty"`
-	SteamOAuthFactor          SteamOAuthFactor                   `json:"steam_oauth_factor,omitempty"`
-	TikTokOAuthFactor         TikTokOAuthFactor                  `json:"tik_tok_oauth_factor,omitempty"`
-	TwitchOAuthFactor         TwitchOAuthFactor                  `json:"twitch_oauth_factor,omitempty"`
-	TwitterOAuthFactor        TwitterOAuthFactor                 `json:"twitter_oauth_factor,omitempty"`
-	EmbeddableMagicLinkFactor EmbeddableMagicLinkFactor          `json:"embeddable_magic_link_factor,omitempty"`
-	BiometricFactor           BiometricFactor                    `json:"biometric_factor,omitempty"`
-	SAMLSSOFactor             SAMLSSOFactor                      `json:"saml_sso_factor,omitempty"`
-	OIDCSSOFactor             OIDCSSOFactor                      `json:"oidc_sso_factor,omitempty"`
-	SalesforceOAuthFactor     SalesforceOAuthFactor              `json:"salesforce_oauth_factor,omitempty"`
-	YahooOAuthFactor          YahooOAuthFactor                   `json:"yahoo_oauth_factor,omitempty"`
+	EmailFactor               *EmailFactor                       `json:"email_factor,omitempty"`
+	PhoneNumberFactor         *PhoneNumberFactor                 `json:"phone_number_factor,omitempty"`
+	GoogleOAuthFactor         *GoogleOAuthFactor                 `json:"google_oauth_factor,omitempty"`
+	MicrosoftOAuthFactor      *MicrosoftOAuthFactor              `json:"microsoft_oauth_factor,omitempty"`
+	AppleOAuthFactor          *AppleOAuthFactor                  `json:"apple_oauth_factor,omitempty"`
+	WebAuthnFactor            *WebAuthnFactor                    `json:"webauthn_factor,omitempty"`
+	AuthenticatorAppFactor    *AuthenticatorAppFactor            `json:"authenticator_app_factor,omitempty"`
+	GithubOAuthFactor         *GithubOAuthFactor                 `json:"github_oauth_factor,omitempty"`
+	RecoveryCodeFactor        *RecoveryCodeFactor                `json:"recovery_code_factor,omitempty"`
+	FacebookOAuthFactor       *FacebookOAuthFactor               `json:"facebook_oauth_factor,omitempty"`
+	CryptoWalletFactor        *CryptoWalletFactor                `json:"crypto_wallet_factor,omitempty"`
+	AmazonOAuthFactor         *AmazonOAuthFactor                 `json:"amazon_oauth_factor,omitempty"`
+	BitbucketOAuthFactor      *BitbucketOAuthFactor              `json:"bitbucket_oauth_factor,omitempty"`
+	CoinbaseOAuthFactor       *CoinbaseOAuthFactor               `json:"coinbase_oauth_factor,omitempty"`
+	DiscordOAuthFactor        *DiscordOAuthFactor                `json:"discord_oauth_factor,omitempty"`
+	FigmaOAuthFactor          *FigmaOAuthFactor                  `json:"figma_oauth_factor,omitempty"`
+	GitLabOAuthFactor         *GitLabOAuthFactor                 `json:"git_lab_oauth_factor,omitempty"`
+	InstagramOAuthFactor      *InstagramOAuthFactor              `json:"instagram_oauth_factor,omitempty"`
+	LinkedInOAuthFactor       *LinkedInOAuthFactor               `json:"linked_in_oauth_factor,omitempty"`
+	ShopifyOAuthFactor        *ShopifyOAuthFactor                `json:"shopify_oauth_factor,omitempty"`
+	SlackOAuthFactor          *SlackOAuthFactor                  `json:"slack_oauth_factor,omitempty"`
+	SnapchatOAuthFactor       *SnapchatOAuthFactor               `json:"snapchat_oauth_factor,omitempty"`
+	SpotifyOAuthFactor        *SpotifyOAuthFactor                `json:"spotify_oauth_factor,omitempty"`
+	SteamOAuthFactor          *SteamOAuthFactor                  `json:"steam_oauth_factor,omitempty"`
+	TikTokOAuthFactor         *TikTokOAuthFactor                 `json:"tik_tok_oauth_factor,omitempty"`
+	TwitchOAuthFactor         *TwitchOAuthFactor                 `json:"twitch_oauth_factor,omitempty"`
+	TwitterOAuthFactor        *TwitterOAuthFactor                `json:"twitter_oauth_factor,omitempty"`
+	EmbeddableMagicLinkFactor *EmbeddableMagicLinkFactor         `json:"embeddable_magic_link_factor,omitempty"`
+	BiometricFactor           *BiometricFactor                   `json:"biometric_factor,omitempty"`
+	SAMLSSOFactor             *SAMLSSOFactor                     `json:"saml_sso_factor,omitempty"`
+	OIDCSSOFactor             *OIDCSSOFactor                     `json:"oidc_sso_factor,omitempty"`
+	SalesforceOAuthFactor     *SalesforceOAuthFactor             `json:"salesforce_oauth_factor,omitempty"`
+	YahooOAuthFactor          *YahooOAuthFactor                  `json:"yahoo_oauth_factor,omitempty"`
 }
 type AuthenticatorAppFactor struct {
 	TOTPID string `json:"totp_id,omitempty"`
@@ -235,7 +234,7 @@ type Session struct {
 	// expressed in UTC, e.g. `2021-12-29T12:33:09Z`.
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// CustomClaims: The custom claims map for a Session. Claims can be added to a session during a Sessions
 	// authenticate call.
 	CustomClaims map[string]any `json:"custom_claims,omitempty"`
@@ -437,56 +436,6 @@ type ClaimsWrapper struct {
 
 type SessionWrapper struct {
 	Session ClaimsWrapper `json:"session"`
-}
-
-// IsValid returns an error if there is an issuer or audience mismatch in the claims.
-//
-// Deprecated: JWT claims are validated when the token is parsed. There is no need to call this method.
-func (c Claims) IsValid(projectID string) error {
-	var errs []error
-
-	if !c.verifyIssuer(projectID) {
-		errs = append(errs, jwt.ErrTokenInvalidIssuer)
-	}
-
-	if !c.verifyAudience(projectID) {
-		errs = append(errs, jwt.ErrTokenInvalidAudience)
-	}
-
-	if len(errs) == 0 {
-		return nil
-	}
-	return multiError{errs}
-}
-
-type multiError struct {
-	errs []error
-}
-
-func (me multiError) Error() string {
-	var msgs []string
-	for _, err := range me.errs {
-		msgs = append(msgs, err.Error())
-	}
-	return strings.Join(msgs, ", ")
-}
-
-func (me multiError) Is(target error) bool {
-	for _, err := range me.errs {
-		if errors.Is(err, target) {
-			return true
-		}
-	}
-	return false
-}
-
-func (c *Claims) verifyIssuer(cmp string) bool {
-	issuerSplit := strings.Split(c.RegisteredClaims.Issuer, "/")
-	return len(issuerSplit) == 2 && issuerSplit[1] == cmp
-}
-
-func (c *Claims) verifyAudience(cmp string) bool {
-	return len(c.RegisteredClaims.Audience) == 1 && c.RegisteredClaims.Audience[0] == cmp
 }
 
 // ENDMANUAL(Types)

--- a/stytch/consumer/sessions_test.go
+++ b/stytch/consumer/sessions_test.go
@@ -11,17 +11,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/stytchapi"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/stytchapi"
 
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/config"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/config"
 )
 
 func TestAuthenticateJWTLocal(t *testing.T) {
@@ -114,7 +114,7 @@ func TestAuthenticateJWTLocal(t *testing.T) {
 			StartedAt:      &iat,
 			LastAccessedAt: &iat,
 			ExpiresAt:      &exp,
-			Attributes: attribute.Attributes{
+			Attributes: &attribute.Attributes{
 				IPAddress: "",
 				UserAgent: "",
 			},
@@ -123,7 +123,7 @@ func TestAuthenticateJWTLocal(t *testing.T) {
 					Type:                "magic_link",
 					DeliveryMethod:      "email",
 					LastAuthenticatedAt: &iat,
-					EmailFactor: sessions.EmailFactor{
+					EmailFactor: &sessions.EmailFactor{
 						EmailAddress: "sandbox@stytch.com",
 						EmailID:      "email-live-cca9d7d0-11b6-4167-9385-d7e0c9a77418",
 					},
@@ -151,7 +151,7 @@ func TestAuthenticateJWTLocal(t *testing.T) {
 			StartedAt:      &iat,
 			LastAccessedAt: &iat,
 			ExpiresAt:      &sessionExp,
-			Attributes: attribute.Attributes{
+			Attributes: &attribute.Attributes{
 				IPAddress: "",
 				UserAgent: "",
 			},
@@ -160,7 +160,7 @@ func TestAuthenticateJWTLocal(t *testing.T) {
 					Type:                "magic_link",
 					DeliveryMethod:      "email",
 					LastAuthenticatedAt: &iat,
-					EmailFactor: sessions.EmailFactor{
+					EmailFactor: &sessions.EmailFactor{
 						EmailAddress: "sandbox@stytch.com",
 						EmailID:      "email-live-cca9d7d0-11b6-4167-9385-d7e0c9a77418",
 					},
@@ -264,66 +264,6 @@ func TestAuthenticateWithClaims(t *testing.T) {
 			}
 			assert.Equal(t, expected, claims)
 		}
-	})
-}
-
-func TestClaims_IsValid(t *testing.T) {
-	// TODO(v10): Remove this method. It is no longer needed.
-	t.Run("matching issuer and audience", func(t *testing.T) {
-		claims := sessions.Claims{
-			RegisteredClaims: jwt.RegisteredClaims{
-				Issuer:   "stytch.com/project-test-00000000-0000-0000-0000-000000000000",
-				Audience: jwt.ClaimStrings{"project-test-00000000-0000-0000-0000-000000000000"},
-			},
-		}
-
-		//nolint:staticcheck // SA1019 deprecated
-		err := claims.IsValid("project-test-00000000-0000-0000-0000-000000000000")
-
-		assert.NoError(t, err)
-	})
-
-	t.Run("mismatched issuer", func(t *testing.T) {
-		claims := sessions.Claims{
-			RegisteredClaims: jwt.RegisteredClaims{
-				Issuer:   "stytch.com/project-test-11111111-1111-1111-1111-111111111111",
-				Audience: jwt.ClaimStrings{"project-test-00000000-0000-0000-0000-000000000000"},
-			},
-		}
-
-		//nolint:staticcheck // SA1019 deprecated
-		err := claims.IsValid("project-test-00000000-0000-0000-0000-000000000000")
-
-		assert.ErrorIs(t, err, jwt.ErrTokenInvalidIssuer)
-	})
-
-	t.Run("mismatched audience", func(t *testing.T) {
-		claims := sessions.Claims{
-			RegisteredClaims: jwt.RegisteredClaims{
-				Issuer:   "stytch.com/project-test-00000000-0000-0000-0000-000000000000",
-				Audience: jwt.ClaimStrings{"project-test-11111111-1111-1111-1111-111111111111"},
-			},
-		}
-
-		//nolint:staticcheck // SA1019 deprecated
-		err := claims.IsValid("project-test-00000000-0000-0000-0000-000000000000")
-
-		assert.ErrorIs(t, err, jwt.ErrTokenInvalidAudience)
-	})
-
-	t.Run("both issuer and audience mismatch identifies as either error", func(t *testing.T) {
-		claims := sessions.Claims{
-			RegisteredClaims: jwt.RegisteredClaims{
-				Issuer:   "stytch.com/project-test-11111111-1111-1111-1111-111111111111",
-				Audience: jwt.ClaimStrings{"project-test-22222222-2222-2222-2222-222222222222"},
-			},
-		}
-
-		//nolint:staticcheck // SA1019 deprecated
-		err := claims.IsValid("project-test-00000000-0000-0000-0000-000000000000")
-
-		assert.ErrorIs(t, err, jwt.ErrTokenInvalidIssuer)
-		assert.ErrorIs(t, err, jwt.ErrTokenInvalidAudience)
 	})
 }
 
@@ -489,7 +429,7 @@ func sandboxClaims(t *testing.T, iat, exp time.Time) sessions.Claims {
 					Type:                "magic_link",
 					DeliveryMethod:      "email",
 					LastAuthenticatedAt: &iat,
-					EmailFactor: sessions.EmailFactor{
+					EmailFactor: &sessions.EmailFactor{
 						EmailAddress: "sandbox@stytch.com",
 						EmailID:      "email-live-cca9d7d0-11b6-4167-9385-d7e0c9a77418",
 					},

--- a/stytch/consumer/stytchapi/stytchapi.go
+++ b/stytch/consumer/stytchapi/stytchapi.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/config"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/config"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer"
 )
 
 type Logger interface {

--- a/stytch/consumer/stytchapi/stytchapi_test.go
+++ b/stytch/consumer/stytchapi/stytchapi_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/stytchapi"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/stytchapi"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/stytch/consumer/totps.go
+++ b/stytch/consumer/totps.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/totps"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/totps"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type TOTPsClient struct {

--- a/stytch/consumer/totps/types.go
+++ b/stytch/consumer/totps/types.go
@@ -7,8 +7,8 @@ package totps
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `TOTPs.Authenticate`.
@@ -130,7 +130,7 @@ type AuthenticateResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	Session sessions.Session `json:"session,omitempty"`
+	Session *sessions.Session `json:"session,omitempty"`
 }
 
 // CreateResponse: Response type for `TOTPs.Create`.
@@ -185,7 +185,7 @@ type RecoverResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	Session sessions.Session `json:"session,omitempty"`
+	Session *sessions.Session `json:"session,omitempty"`
 }
 
 // RecoveryCodesResponse: Response type for `TOTPs.RecoveryCodes`.

--- a/stytch/consumer/users.go
+++ b/stytch/consumer/users.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type UsersClient struct {

--- a/stytch/consumer/users/types.go
+++ b/stytch/consumer/users/types.go
@@ -9,7 +9,7 @@ package users
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
 )
 
 // BiometricRegistration:
@@ -26,9 +26,9 @@ type CreateParams struct {
 	// Email: The email address of the end user.
 	Email string `json:"email,omitempty"`
 	// Name: The name of the user. Each field in the name object is optional.
-	Name Name `json:"name,omitempty"`
+	Name *Name `json:"name,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// PhoneNumber: The phone number to use for one-time passcodes. The phone number should be in E.164 format.
 	// The phone number should be in E.164 format (i.e. +1XXXXXXXXXX). You may use +10000000000 to test this
 	// endpoint, see [Testing](https://stytch.com/docs/home#resources_testing) for more detail.
@@ -238,9 +238,9 @@ type UpdateParams struct {
 	// UserID: The unique ID of a specific User.
 	UserID string `json:"user_id,omitempty"`
 	// Name: The name of the user. Each field in the name object is optional.
-	Name Name `json:"name,omitempty"`
+	Name *Name `json:"name,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
-	Attributes attribute.Attributes `json:"attributes,omitempty"`
+	Attributes *attribute.Attributes `json:"attributes,omitempty"`
 	// TrustedMetadata: The `trusted_metadata` field contains an arbitrary JSON object of application-specific
 	// data. See the [Metadata](https://stytch.com/docs/api/metadata) reference for complete field behavior
 	// details.
@@ -275,12 +275,12 @@ type User struct {
 	// the Stytch API.
 	BiometricRegistrations []BiometricRegistration `json:"biometric_registrations,omitempty"`
 	// Name: The name of the User. Each field in the `name` object is optional.
-	Name Name `json:"name,omitempty"`
+	Name *Name `json:"name,omitempty"`
 	// CreatedAt: The timestamp of the User's creation. Values conform to the RFC 3339 standard and are
 	// expressed in UTC, e.g. `2021-12-29T12:33:09Z`.
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	// Password: The password object is returned for users with a password.
-	Password Password `json:"password,omitempty"`
+	Password *Password `json:"password,omitempty"`
 	// TrustedMetadata: The `trusted_metadata` field contains an arbitrary JSON object of application-specific
 	// data. See the [Metadata](https://stytch.com/docs/api/metadata) reference for complete field behavior
 	// details.
@@ -513,12 +513,12 @@ type GetResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// Name: The name of the User. Each field in the `name` object is optional.
-	Name Name `json:"name,omitempty"`
+	Name *Name `json:"name,omitempty"`
 	// CreatedAt: The timestamp of the User's creation. Values conform to the RFC 3339 standard and are
 	// expressed in UTC, e.g. `2021-12-29T12:33:09Z`.
 	CreatedAt *time.Time `json:"created_at,omitempty"`
 	// Password: The password object is returned for users with a password.
-	Password Password `json:"password,omitempty"`
+	Password *Password `json:"password,omitempty"`
 	// TrustedMetadata: The `trusted_metadata` field contains an arbitrary JSON object of application-specific
 	// data. See the [Metadata](https://stytch.com/docs/api/metadata) reference for complete field behavior
 	// details.

--- a/stytch/consumer/webauthn.go
+++ b/stytch/consumer/webauthn.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v10/stytch"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/webauthn"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/webauthn"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 type WebAuthnClient struct {

--- a/stytch/consumer/webauthn/types.go
+++ b/stytch/consumer/webauthn/types.go
@@ -7,8 +7,8 @@ package webauthn
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v10/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `WebAuthn.Authenticate`.
@@ -99,7 +99,7 @@ type AuthenticateResponse struct {
 	//
 	//   See [GET sessions](https://stytch.com/docs/api/session-get) for complete response fields.
 	//
-	Session sessions.Session `json:"session,omitempty"`
+	Session *sessions.Session `json:"session,omitempty"`
 }
 
 // AuthenticateStartResponse: Response type for `WebAuthn.AuthenticateStart`.

--- a/stytch/stytch.go
+++ b/stytch/stytch.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/stytchauth/stytch-go/v10/stytch/config"
-	"github.com/stytchauth/stytch-go/v10/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v11/stytch/config"
+	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 )
 
 const (

--- a/stytch/stytcherror/stytcherror.go
+++ b/stytch/stytcherror/stytcherror.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/stytchauth/stytch-go/v10/stytch/config"
+	"github.com/stytchauth/stytch-go/v11/stytch/config"
 )
 
 type Error struct {


### PR DESCRIPTION
This would be a breaking change (and push us to v11), but would uniformly fix issues like the one reported today of the unwieldiness of certain search operations.

`Organizations.Search()` currently has the problem that a Query *must* be given or it fails to be parsed properly. For example, this is totally valid in cURL:
```
curl -X POST --url https://test.stytch.com/v1/b2b/organizations/search \
	-H "Content-Type: application/json" \
	-u "$projectID:$secret"
```

but this fails in the Go SDK:
```go
	client, err := b2bstytchapi.NewClient("project-id", "secret")
	if err != nil {
		panic(err)
	}

	params := &members.SearchParams{
		OrganizationIds: []string{"organization-id"},
	}

	response, err := client.Organizations.Members.Search(context.Background(), params)
	if err != nil {
		panic(err)
	}

	fmt.Println(response)
```

We had already special-cased `Users.Search`, but it doesn't address the underlying issue: there are a number of types that should be pointers that instead get sent as "zero structs" and then misinterpreted by the API.

## Testing

On v11, the code above succeeds:

```go
	client, err := b2bstytchapi.NewClient("project-id", "secret")
	if err != nil {
		panic(err)
	}

	params := &members.SearchParams{
		OrganizationIds: []string{"organization-id"},
	}

	response, err := client.Organizations.Members.Search(context.Background(), params)
	if err != nil {
		panic(err)
	}

	fmt.Println(response)
```