### PR TITLE
Fix stytch-go NewClient with override http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import (
 	"context"
 
 	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2c/stytchapi"
+	"github.com/stytchauth/stytch-go/v11/stytch/consumer/stytchapi"
 )
 
 stytchAPIClient, err := stytchapi.NewClient(

--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -127,11 +127,7 @@ func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
 	a.SSO = b2b.NewSSOClient(a.client)
 	a.Sessions = b2b.NewSessionsClient(a.client)
 	// Set up JWKS for local session authentication
-	httpClient := defaultClient.HTTPClient
-	if realClient, ok := a.client.(*stytch.DefaultClient); ok {
-		httpClient = realClient.HTTPClient
-	}
-	jwks, err := a.instantiateJWKSClient(httpClient)
+	jwks, err := a.instantiateJWKSClient(a.client.GetHTTPClient())
 	if err != nil {
 		return nil, fmt.Errorf("fetch JWKS from URL: %w", err)
 	}

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "11.1.0"
+const APIVersion = "11.1.1"

--- a/stytch/consumer/stytchapi/stytchapi.go
+++ b/stytch/consumer/stytchapi/stytchapi.go
@@ -128,11 +128,7 @@ func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
 	a.Users = consumer.NewUsersClient(a.client)
 	a.WebAuthn = consumer.NewWebAuthnClient(a.client)
 	// Set up JWKS for local session authentication
-	httpClient := defaultClient.HTTPClient
-	if realClient, ok := a.client.(*stytch.DefaultClient); ok {
-		httpClient = realClient.HTTPClient
-	}
-	jwks, err := a.instantiateJWKSClient(httpClient)
+	jwks, err := a.instantiateJWKSClient(a.client.GetHTTPClient())
 	if err != nil {
 		return nil, fmt.Errorf("fetch JWKS from URL: %w", err)
 	}


### PR DESCRIPTION
External bug report that we weren't properly handling the underlying realClient. I believe the cause was two different PRs that went out close to one another and we just got mixed up handling the httpClient.

# Testing
Created this test file locally (using real values instead of the `REDACTED` fields):
![image](https://github.com/stytchauth/stytch-go/assets/119902778/a1e463e4-cb37-4ec2-b106-9a19c2115149)

And then running it:
![image](https://github.com/stytchauth/stytch-go/assets/119902778/c39923bb-9847-4132-885b-e103a949177e)
