### PR TITLE
Add option to skip JWKS initialization

### DIFF
--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -101,8 +101,9 @@ func WithInitializationContext(ctx context.Context) Option {
 }
 
 // WithSkipJWKSInitialization skips the initialization of the JWKS client. This can be useful for testing purposes.
-// Please note that if you utilize this option, any API method that makes use of the JWKS client will panic with a nil
-// pointer dereference. If possible, it is recommended to provide a
+// Please note that if you utilize this option, any API method that makes use of the JWKS client will raise a
+// stytcherror.JWKSNotInitialized error. If you need to call such a method, you should use WithClient or WithHTTPClient
+// with a client that is capable of ininitalizing the JWKS keyfunc.
 func WithSkipJWKSInitialization() Option {
 	return func(api *API) { api.shouldSkipJWKSInitialization = true }
 }

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "11.1.2"
+const APIVersion = "11.2.0"

--- a/stytch/consumer/m2m.go
+++ b/stytch/consumer/m2m.go
@@ -130,6 +130,7 @@ func (c *M2MClient) Token(
 // ADDIMPORT: "time"
 // ADDIMPORT: "github.com/golang-jwt/jwt/v5"
 // ADDIMPORT: "github.com/MicahParks/keyfunc/v2"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 
 // AuthenticateToken validates an access token issued by Stytch from the Token endpoint.
 // M2M access tokens are JWTs signed with the project's JWKs, and can be validated locally using any Stytch client library.
@@ -138,6 +139,10 @@ func (c *M2MClient) AuthenticateToken(
 	ctx context.Context,
 	req *m2m.AuthenticateTokenParams,
 ) (*m2m.AuthenticateTokenResponse, error) {
+	if c.JWKS == nil {
+		return nil, stytcherror.ErrJWKSNotInitialized
+	}
+
 	var claims jwt.MapClaims
 
 	aud := c.C.GetConfig().ProjectID

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -195,6 +195,7 @@ func (c *SessionsClient) GetJWKS(
 // ADDIMPORT: "time"
 // ADDIMPORT: "github.com/golang-jwt/jwt/v5"
 // ADDIMPORT: "github.com/MicahParks/keyfunc/v2"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
 
 func (c *SessionsClient) AuthenticateJWT(
 	ctx context.Context,
@@ -241,6 +242,10 @@ func (c *SessionsClient) AuthenticateJWTLocal(
 	token string,
 	maxTokenAge time.Duration,
 ) (*sessions.Session, error) {
+	if c.JWKS == nil {
+		return nil, stytcherror.ErrJWKSNotInitialized
+	}
+
 	var claims sessions.Claims
 
 	aud := c.C.GetConfig().ProjectID

--- a/stytch/consumer/stytchapi/stytchapi.go
+++ b/stytch/consumer/stytchapi/stytchapi.go
@@ -31,6 +31,8 @@ type API struct {
 	initializationContext context.Context
 	logger                Logger
 
+	shouldSkipJWKSInitialization bool
+
 	CryptoWallets *consumer.CryptoWalletsClient
 	M2M           *consumer.M2MClient
 	MagicLinks    *consumer.MagicLinksClient
@@ -98,6 +100,13 @@ func WithInitializationContext(ctx context.Context) Option {
 	return func(api *API) { api.initializationContext = ctx }
 }
 
+// WithSkipJWKSInitialization skips the initialization of the JWKS client. This can be useful for testing purposes.
+// Please note that if you utilize this option, any API method that makes use of the JWKS client will panic with a nil
+// pointer dereference. If possible, it is recommended to provide a
+func WithSkipJWKSInitialization() Option {
+	return func(api *API) { api.shouldSkipJWKSInitialization = true }
+}
+
 // NewClient returns a Stytch API client that uses the provided credentials.
 //
 // It detects the environment from the given projectID. You are still free to pass WithBaseURI as an option if you wish
@@ -112,6 +121,8 @@ func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
 
 		client:                defaultClient,
 		initializationContext: context.Background(),
+
+		shouldSkipJWKSInitialization: false,
 	}
 	for _, o := range opts {
 		o(a)
@@ -140,6 +151,12 @@ func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
 }
 
 func (a *API) instantiateJWKSClient(httpClient *http.Client) (*keyfunc.JWKS, error) {
+	if a.shouldSkipJWKSInitialization {
+		if a.logger != nil {
+			a.logger.Printf("Skipping JWKS initialization")
+		}
+		return nil, nil
+	}
 	// The context given in the keyfunc Options applies throughout the lifetime of the JWKS
 	// fetcher. The context we were given here is _only_ for init, so we arrange to cancel the
 	// JWKS context manually if we couldn't start in time.

--- a/stytch/consumer/stytchapi/stytchapi.go
+++ b/stytch/consumer/stytchapi/stytchapi.go
@@ -101,8 +101,9 @@ func WithInitializationContext(ctx context.Context) Option {
 }
 
 // WithSkipJWKSInitialization skips the initialization of the JWKS client. This can be useful for testing purposes.
-// Please note that if you utilize this option, any API method that makes use of the JWKS client will panic with a nil
-// pointer dereference. If possible, it is recommended to provide a
+// Please note that if you utilize this option, any API method that makes use of the JWKS client will raise a
+// stytcherror.JWKSNotInitialized error. If you need to call such a method, you should use WithClient or WithHTTPClient
+// with a client that is capable of ininitalizing the JWKS keyfunc.
 func WithSkipJWKSInitialization() Option {
 	return func(api *API) { api.shouldSkipJWKSInitialization = true }
 }

--- a/stytch/stytcherror/stytcherror.go
+++ b/stytch/stytcherror/stytcherror.go
@@ -1,6 +1,7 @@
 package stytcherror
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -75,3 +76,5 @@ func NewClientLibraryError(message string) error {
 		ErrorURL:     "https://stytch.com/docs/api/errors/500",
 	}
 }
+
+var ErrJWKSNotInitialized = errors.New("JWKS not initialized")


### PR DESCRIPTION
Adds a WithSkipJWKSInitialization for projects that want to override the default client but do *not* provide an easy way to initialize the JWKS client. This is somewhat common for testing purposes.

Please note that if you skip JWKS initialization and then call an API method that uses JWKS, it **will** try to dereference a `nil` pointer.

# Testing
Used a simple test.go script that skipped JWKS and sent an EML
![image](https://github.com/stytchauth/stytch-go/assets/119902778/944f12c9-5cb2-444c-9b2c-e794fe2ebfb1)
