### PR TITLE
Fix import path for new major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It pairs well with the Stytch [Web SDK](https://www.npmjs.com/package/@stytch/va
 ## Install
 
 ```console
-$ go get github.com/stytchauth/stytch-go/v11
+$ go get github.com/stytchauth/stytch-go/v12
 ```
 
 ## Usage
@@ -35,8 +35,8 @@ Create an API client:
 import (
 	"context"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/stytchapi"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/stytchapi"
 )
 
 stytchAPIClient, err := stytchapi.NewClient(

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/stytchauth/stytch-go/v11
+module github.com/stytchauth/stytch-go/v12
 
 go 1.18
 

--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b"
-	"github.com/stytchauth/stytch-go/v11/stytch/config"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b"
+	"github.com/stytchauth/stytch-go/v12/stytch/config"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer"
 )
 
 type Logger interface {

--- a/stytch/b2b/discovery.go
+++ b/stytch/b2b/discovery.go
@@ -7,7 +7,7 @@ package b2b
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch"
 )
 
 type DiscoveryClient struct {

--- a/stytch/b2b/discovery/intermediatesessions/types.go
+++ b/stytch/b2b/discovery/intermediatesessions/types.go
@@ -7,9 +7,9 @@ package intermediatesessions
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
 )
 
 // ExchangeParams: Request type for `IntermediateSessions.Exchange`.

--- a/stytch/b2b/discovery/organizations/types.go
+++ b/stytch/b2b/discovery/organizations/types.go
@@ -7,10 +7,10 @@ package organizations
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/discovery"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/discovery"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
 )
 
 // CreateParams: Request type for `Organizations.Create`.

--- a/stytch/b2b/discovery/types.go
+++ b/stytch/b2b/discovery/types.go
@@ -7,8 +7,8 @@ package discovery
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
 )
 
 // DiscoveredOrganization:

--- a/stytch/b2b/discovery_intermediatesessions.go
+++ b/stytch/b2b/discovery_intermediatesessions.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/discovery/intermediatesessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/discovery/intermediatesessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type DiscoveryIntermediateSessionsClient struct {

--- a/stytch/b2b/discovery_organizations.go
+++ b/stytch/b2b/discovery_organizations.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/discovery/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/discovery/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type DiscoveryOrganizationsClient struct {

--- a/stytch/b2b/magiclinks.go
+++ b/stytch/b2b/magiclinks.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/magiclinks"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/magiclinks"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type MagicLinksClient struct {

--- a/stytch/b2b/magiclinks/discovery/types.go
+++ b/stytch/b2b/magiclinks/discovery/types.go
@@ -7,7 +7,7 @@ package discovery
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/discovery"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/discovery"
 )
 
 // AuthenticateParams: Request type for `Discovery.Authenticate`.

--- a/stytch/b2b/magiclinks/email/types.go
+++ b/stytch/b2b/magiclinks/email/types.go
@@ -7,8 +7,8 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/methodoptions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/methodoptions"
 )
 
 // InviteParams: Request type for `Email.Invite`.

--- a/stytch/b2b/magiclinks/types.go
+++ b/stytch/b2b/magiclinks/types.go
@@ -7,9 +7,9 @@ package magiclinks
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
 )
 
 // AuthenticateParams: Request type for `MagicLinks.Authenticate`.

--- a/stytch/b2b/magiclinks_discovery.go
+++ b/stytch/b2b/magiclinks_discovery.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/magiclinks/discovery"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/magiclinks/discovery"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type MagicLinksDiscoveryClient struct {

--- a/stytch/b2b/magiclinks_email.go
+++ b/stytch/b2b/magiclinks_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/magiclinks/email"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/magiclinks/email"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type MagicLinksEmailClient struct {

--- a/stytch/b2b/magiclinks_email_discovery.go
+++ b/stytch/b2b/magiclinks_email_discovery.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/magiclinks/email/discovery"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/magiclinks/email/discovery"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type MagicLinksEmailDiscoveryClient struct {

--- a/stytch/b2b/oauth.go
+++ b/stytch/b2b/oauth.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/oauth"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/oauth"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type OAuthClient struct {

--- a/stytch/b2b/oauth/discovery/types.go
+++ b/stytch/b2b/oauth/discovery/types.go
@@ -7,7 +7,7 @@ package discovery
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/discovery"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/discovery"
 )
 
 // AuthenticateParams: Request type for `Discovery.Authenticate`.

--- a/stytch/b2b/oauth/types.go
+++ b/stytch/b2b/oauth/types.go
@@ -9,9 +9,9 @@ package oauth
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
 )
 
 // AuthenticateParams: Request type for `OAuth.Authenticate`.

--- a/stytch/b2b/oauth_discovery.go
+++ b/stytch/b2b/oauth_discovery.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/oauth/discovery"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/oauth/discovery"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type OAuthDiscoveryClient struct {

--- a/stytch/b2b/organizations.go
+++ b/stytch/b2b/organizations.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type OrganizationsClient struct {

--- a/stytch/b2b/organizations/members/types.go
+++ b/stytch/b2b/organizations/members/types.go
@@ -7,8 +7,8 @@ package members
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/methodoptions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/methodoptions"
 )
 
 // CreateParams: Request type for `Members.Create`.

--- a/stytch/b2b/organizations/types.go
+++ b/stytch/b2b/organizations/types.go
@@ -7,7 +7,7 @@ package organizations
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/methodoptions"
+	"github.com/stytchauth/stytch-go/v12/stytch/methodoptions"
 )
 
 // ActiveSSOConnection:

--- a/stytch/b2b/organizations_members.go
+++ b/stytch/b2b/organizations_members.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations/members"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations/members"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type OrganizationsMembersClient struct {

--- a/stytch/b2b/otp.go
+++ b/stytch/b2b/otp.go
@@ -7,7 +7,7 @@ package b2b
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch"
 )
 
 type OTPsClient struct {

--- a/stytch/b2b/otp/sms/types.go
+++ b/stytch/b2b/otp/sms/types.go
@@ -7,8 +7,8 @@ package sms
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
 )
 
 // AuthenticateParams: Request type for `Sms.Authenticate`.

--- a/stytch/b2b/otp_sms.go
+++ b/stytch/b2b/otp_sms.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/otp/sms"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/otp/sms"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type OTPsSmsClient struct {

--- a/stytch/b2b/passwords.go
+++ b/stytch/b2b/passwords.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/passwords"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/passwords"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type PasswordsClient struct {

--- a/stytch/b2b/passwords/email/types.go
+++ b/stytch/b2b/passwords/email/types.go
@@ -7,9 +7,9 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
 )
 
 // ResetParams: Request type for `Email.Reset`.

--- a/stytch/b2b/passwords/existingpassword/types.go
+++ b/stytch/b2b/passwords/existingpassword/types.go
@@ -7,9 +7,9 @@ package existingpassword
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
 )
 
 // ResetParams: Request type for `ExistingPassword.Reset`.

--- a/stytch/b2b/passwords/session/types.go
+++ b/stytch/b2b/passwords/session/types.go
@@ -7,9 +7,9 @@ package session
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
 )
 
 // ResetParams: Request type for `Sessions.Reset`.

--- a/stytch/b2b/passwords/types.go
+++ b/stytch/b2b/passwords/types.go
@@ -7,10 +7,10 @@ package passwords
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/passwords"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/passwords"
 )
 
 // AuthenticateParams: Request type for `Passwords.Authenticate`.

--- a/stytch/b2b/passwords_email.go
+++ b/stytch/b2b/passwords_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/passwords/email"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/passwords/email"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type PasswordsEmailClient struct {

--- a/stytch/b2b/passwords_existingpassword.go
+++ b/stytch/b2b/passwords_existingpassword.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/passwords/existingpassword"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/passwords/existingpassword"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type PasswordsExistingPasswordClient struct {

--- a/stytch/b2b/passwords_session.go
+++ b/stytch/b2b/passwords_session.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/passwords/session"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/passwords/session"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type PasswordsSessionsClient struct {

--- a/stytch/b2b/rbac.go
+++ b/stytch/b2b/rbac.go
@@ -10,8 +10,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/rbac"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/rbac"
 )
 
 type RBACClient struct {

--- a/stytch/b2b/sessions.go
+++ b/stytch/b2b/sessions.go
@@ -15,11 +15,11 @@ import (
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/rbac"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/shared"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/rbac"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/shared"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type SessionsClient struct {
@@ -293,7 +293,7 @@ func (c *SessionsClient) GetJWKS(
 // ADDIMPORT: "time"
 // ADDIMPORT: "github.com/golang-jwt/jwt/v5"
 // ADDIMPORT: "github.com/MicahParks/keyfunc/v2"
-// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 
 func (c *SessionsClient) AuthenticateJWT(
 	ctx context.Context,
@@ -335,7 +335,7 @@ func (c *SessionsClient) AuthenticateJWTWithClaims(
 	}, nil
 }
 
-// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/shared"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v12/stytch/shared"
 func (c *SessionsClient) AuthenticateJWTLocal(
 	ctx context.Context,
 	token string,

--- a/stytch/b2b/sessions/types.go
+++ b/stytch/b2b/sessions/types.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
 )
 
 // AuthenticateParams: Request type for `Sessions.Authenticate`.
@@ -322,7 +322,7 @@ const (
 // ADDIMPORT: "errors"
 // ADDIMPORT: "strings"
 // ADDIMPORT: "github.com/golang-jwt/jwt/v5"
-// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
 
 var ErrJWTTooOld = errors.New("JWT too old")
 

--- a/stytch/b2b/sessions_test.go
+++ b/stytch/b2b/sessions_test.go
@@ -11,17 +11,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/b2bstytchapi"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
-	consumersessions "github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/b2bstytchapi"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
+	consumersessions "github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
 
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/config"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/config"
 )
 
 func TestAuthenticateJWTLocal(t *testing.T) {

--- a/stytch/b2b/sso.go
+++ b/stytch/b2b/sso.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sso"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sso"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type SSOClient struct {

--- a/stytch/b2b/sso/oidc/types.go
+++ b/stytch/b2b/sso/oidc/types.go
@@ -7,8 +7,8 @@ package oidc
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sso"
-	"github.com/stytchauth/stytch-go/v11/stytch/methodoptions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sso"
+	"github.com/stytchauth/stytch-go/v12/stytch/methodoptions"
 )
 
 // CreateConnectionParams: Request type for `OIDC.CreateConnection`.

--- a/stytch/b2b/sso/saml/types.go
+++ b/stytch/b2b/sso/saml/types.go
@@ -7,8 +7,8 @@ package saml
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sso"
-	"github.com/stytchauth/stytch-go/v11/stytch/methodoptions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sso"
+	"github.com/stytchauth/stytch-go/v12/stytch/methodoptions"
 )
 
 // CreateConnectionParams: Request type for `SAML.CreateConnection`.

--- a/stytch/b2b/sso/types.go
+++ b/stytch/b2b/sso/types.go
@@ -9,10 +9,10 @@ package sso
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/mfa"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/organizations"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/methodoptions"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/mfa"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/organizations"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/methodoptions"
 )
 
 // AuthenticateParams: Request type for `SSO.Authenticate`.

--- a/stytch/b2b/sso_oidc.go
+++ b/stytch/b2b/sso_oidc.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sso/oidc"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sso/oidc"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type SSOOIDCClient struct {

--- a/stytch/b2b/sso_saml.go
+++ b/stytch/b2b/sso_saml.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sso/saml"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sso/saml"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type SSOSAMLClient struct {

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "12.0.1"
+const APIVersion = "12.0.2"

--- a/stytch/consumer/cryptowallets.go
+++ b/stytch/consumer/cryptowallets.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/cryptowallets"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/cryptowallets"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type CryptoWalletsClient struct {

--- a/stytch/consumer/cryptowallets/types.go
+++ b/stytch/consumer/cryptowallets/types.go
@@ -7,8 +7,8 @@ package cryptowallets
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `CryptoWallets.Authenticate`.

--- a/stytch/consumer/m2m.go
+++ b/stytch/consumer/m2m.go
@@ -18,10 +18,10 @@ import (
 
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/config"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/config"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/m2m"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type M2MClient struct {
@@ -42,9 +42,9 @@ func NewM2MClient(c stytch.Client, jwks *keyfunc.JWKS) *M2MClient {
 // MANUAL(Token)(SERVICE_METHOD)
 // ADDIMPORT: "context"
 // ADDIMPORT: "fmt"
-// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/config"
-// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m"
-// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v12/stytch/config"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v12/stytch/consumer/m2m"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 // ADDIMPORT: "io"
 // ADDIMPORT: "net/http"
 // ADDIMPORT: "net/url"
@@ -132,7 +132,7 @@ func (c *M2MClient) Token(
 // ADDIMPORT: "time"
 // ADDIMPORT: "github.com/golang-jwt/jwt/v5"
 // ADDIMPORT: "github.com/MicahParks/keyfunc/v2"
-// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 
 // AuthenticateToken validates an access token issued by Stytch from the Token endpoint.
 // M2M access tokens are JWTs signed with the project's JWKs, and can be validated locally using any Stytch client library.

--- a/stytch/consumer/m2m/clients/secrets/types.go
+++ b/stytch/consumer/m2m/clients/secrets/types.go
@@ -7,7 +7,7 @@ package secrets
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/m2m"
 )
 
 // RotateCancelParams: Request type for `Secrets.RotateCancel`.

--- a/stytch/consumer/m2m/clients/types.go
+++ b/stytch/consumer/m2m/clients/types.go
@@ -7,7 +7,7 @@ package clients
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/m2m"
 )
 
 // CreateParams: Request type for `Clients.Create`.

--- a/stytch/consumer/m2m_clients.go
+++ b/stytch/consumer/m2m_clients.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m/clients"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/m2m/clients"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type M2MClientsClient struct {

--- a/stytch/consumer/m2m_clients_secrets.go
+++ b/stytch/consumer/m2m_clients_secrets.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m/clients/secrets"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/m2m/clients/secrets"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type M2MClientsSecretsClient struct {

--- a/stytch/consumer/m2m_test.go
+++ b/stytch/consumer/m2m_test.go
@@ -9,16 +9,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/config"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/m2m"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/config"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/m2m"
 )
 
 func TestM2MClient_Token(t *testing.T) {

--- a/stytch/consumer/magiclinks.go
+++ b/stytch/consumer/magiclinks.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type MagicLinksClient struct {

--- a/stytch/consumer/magiclinks/email/types.go
+++ b/stytch/consumer/magiclinks/email/types.go
@@ -7,8 +7,8 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 // InviteParams: Request type for `Email.Invite`.

--- a/stytch/consumer/magiclinks/types.go
+++ b/stytch/consumer/magiclinks/types.go
@@ -7,9 +7,9 @@ package magiclinks
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `MagicLinks.Authenticate`.

--- a/stytch/consumer/magiclinks_email.go
+++ b/stytch/consumer/magiclinks_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/magiclinks/email"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/magiclinks/email"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type MagicLinksEmailClient struct {

--- a/stytch/consumer/oauth.go
+++ b/stytch/consumer/oauth.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/oauth"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/oauth"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type OAuthClient struct {

--- a/stytch/consumer/oauth/types.go
+++ b/stytch/consumer/oauth/types.go
@@ -9,8 +9,8 @@ package oauth
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 // AttachParams: Request type for `OAuth.Attach`.

--- a/stytch/consumer/otp.go
+++ b/stytch/consumer/otp.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/otp"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/otp"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type OTPsClient struct {

--- a/stytch/consumer/otp/email/types.go
+++ b/stytch/consumer/otp/email/types.go
@@ -7,7 +7,7 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/attribute"
 )
 
 // LoginOrCreateParams: Request type for `Email.LoginOrCreate`.

--- a/stytch/consumer/otp/sms/types.go
+++ b/stytch/consumer/otp/sms/types.go
@@ -7,7 +7,7 @@ package sms
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/attribute"
 )
 
 // LoginOrCreateParams: Request type for `Sms.LoginOrCreate`.

--- a/stytch/consumer/otp/types.go
+++ b/stytch/consumer/otp/types.go
@@ -7,10 +7,10 @@ package otp
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `OTPs.Authenticate`.

--- a/stytch/consumer/otp/whatsapp/types.go
+++ b/stytch/consumer/otp/whatsapp/types.go
@@ -7,7 +7,7 @@ package whatsapp
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/attribute"
 )
 
 // LoginOrCreateParams: Request type for `Whatsapp.LoginOrCreate`.

--- a/stytch/consumer/otp_email.go
+++ b/stytch/consumer/otp_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/otp/email"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/otp/email"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type OTPsEmailClient struct {

--- a/stytch/consumer/otp_sms.go
+++ b/stytch/consumer/otp_sms.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/otp/sms"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/otp/sms"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type OTPsSmsClient struct {

--- a/stytch/consumer/otp_whatsapp.go
+++ b/stytch/consumer/otp_whatsapp.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/otp/whatsapp"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/otp/whatsapp"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type OTPsWhatsappClient struct {

--- a/stytch/consumer/passwords.go
+++ b/stytch/consumer/passwords.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/passwords"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/passwords"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type PasswordsClient struct {

--- a/stytch/consumer/passwords/email/types.go
+++ b/stytch/consumer/passwords/email/types.go
@@ -7,10 +7,10 @@ package email
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 // ResetParams: Request type for `Email.Reset`.

--- a/stytch/consumer/passwords/existingpassword/types.go
+++ b/stytch/consumer/passwords/existingpassword/types.go
@@ -7,8 +7,8 @@ package existingpassword
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 // ResetParams: Request type for `ExistingPassword.Reset`.

--- a/stytch/consumer/passwords/session/types.go
+++ b/stytch/consumer/passwords/session/types.go
@@ -7,8 +7,8 @@ package session
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 // ResetParams: Request type for `Sessions.Reset`.

--- a/stytch/consumer/passwords/types.go
+++ b/stytch/consumer/passwords/types.go
@@ -7,8 +7,8 @@ package passwords
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 // Argon2Config:

--- a/stytch/consumer/passwords_email.go
+++ b/stytch/consumer/passwords_email.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/passwords/email"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/passwords/email"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type PasswordsEmailClient struct {

--- a/stytch/consumer/passwords_existingpassword.go
+++ b/stytch/consumer/passwords_existingpassword.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/passwords/existingpassword"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/passwords/existingpassword"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type PasswordsExistingPasswordClient struct {

--- a/stytch/consumer/passwords_session.go
+++ b/stytch/consumer/passwords_session.go
@@ -10,9 +10,9 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/passwords/session"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/passwords/session"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type PasswordsSessionsClient struct {

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -15,9 +15,9 @@ import (
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type SessionsClient struct {
@@ -225,7 +225,7 @@ func (c *SessionsClient) GetJWKS(
 // ADDIMPORT: "time"
 // ADDIMPORT: "github.com/golang-jwt/jwt/v5"
 // ADDIMPORT: "github.com/MicahParks/keyfunc/v2"
-// ADDIMPORT: "github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+// ADDIMPORT: "github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 
 func (c *SessionsClient) AuthenticateJWT(
 	ctx context.Context,

--- a/stytch/consumer/sessions/types.go
+++ b/stytch/consumer/sessions/types.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 type AmazonOAuthFactor struct {

--- a/stytch/consumer/sessions_test.go
+++ b/stytch/consumer/sessions_test.go
@@ -11,17 +11,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/stytchapi"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/stytchapi"
 
 	"github.com/MicahParks/keyfunc/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/config"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/config"
 )
 
 func TestAuthenticateJWTLocal(t *testing.T) {

--- a/stytch/consumer/stytchapi/stytchapi.go
+++ b/stytch/consumer/stytchapi/stytchapi.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/config"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/config"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer"
 )
 
 type Logger interface {

--- a/stytch/consumer/stytchapi/stytchapi_test.go
+++ b/stytch/consumer/stytchapi/stytchapi_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/magiclinks"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/stytchapi"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/magiclinks"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/stytchapi"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/stytch/consumer/totps.go
+++ b/stytch/consumer/totps.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/totps"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/totps"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type TOTPsClient struct {

--- a/stytch/consumer/totps/types.go
+++ b/stytch/consumer/totps/types.go
@@ -7,8 +7,8 @@ package totps
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `TOTPs.Authenticate`.

--- a/stytch/consumer/users.go
+++ b/stytch/consumer/users.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type UsersClient struct {

--- a/stytch/consumer/users/types.go
+++ b/stytch/consumer/users/types.go
@@ -9,7 +9,7 @@ package users
 import (
 	"time"
 
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/attribute"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/attribute"
 )
 
 // BiometricRegistration:

--- a/stytch/consumer/webauthn.go
+++ b/stytch/consumer/webauthn.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/stytchauth/stytch-go/v11/stytch"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/webauthn"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/webauthn"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 type WebAuthnClient struct {

--- a/stytch/consumer/webauthn/types.go
+++ b/stytch/consumer/webauthn/types.go
@@ -7,8 +7,8 @@ package webauthn
 // !!!
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/consumer/users"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/consumer/users"
 )
 
 // AuthenticateParams: Request type for `WebAuthn.Authenticate`.

--- a/stytch/shared/rbac_local.go
+++ b/stytch/shared/rbac_local.go
@@ -1,9 +1,9 @@
 package shared
 
 import (
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/rbac"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/rbac"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 func PerformAuthorizationCheck(

--- a/stytch/shared/rbac_local_test.go
+++ b/stytch/shared/rbac_local_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/rbac"
-	"github.com/stytchauth/stytch-go/v11/stytch/b2b/sessions"
-	"github.com/stytchauth/stytch-go/v11/stytch/shared"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/rbac"
+	"github.com/stytchauth/stytch-go/v12/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/shared"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 const orgID = "organization-1234"

--- a/stytch/stytch.go
+++ b/stytch/stytch.go
@@ -10,8 +10,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/stytchauth/stytch-go/v11/stytch/config"
-	"github.com/stytchauth/stytch-go/v11/stytch/stytcherror"
+	"github.com/stytchauth/stytch-go/v12/stytch/config"
+	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
 const (

--- a/stytch/stytcherror/stytcherror.go
+++ b/stytch/stytcherror/stytcherror.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/stytchauth/stytch-go/v11/stytch/config"
+	"github.com/stytchauth/stytch-go/v12/stytch/config"
 )
 
 type Error struct {


### PR DESCRIPTION
We missed a step when releasing v12 of this library: changing the import path to say v12 instead of v11. This fixes that and prepares for releasing it as a patch update.

- fix(go.mod): Update module path for new major version
- fix: Update import paths for new module path
- Bump patch version for release
