### PR TITLE
fix: Return custom claims when authenticating a JWT locally

### DIFF
--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "12.2.0"
+const APIVersion = "12.2.1"

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -93,9 +93,13 @@ func (c *SessionsClient) Authenticate(
 }
 
 // AuthenticateWithClaims fills in the claims pointer with custom claims from the response.
-// Pass in a map with the types of values you're expecting so that this function can marshal
-// the claims from the response. See ExampleClient_AuthenticateWithClaims_map,
-// ExampleClient_AuthenticateWithClaims_struct for examples
+//
+// The value for claims must be one of these types:
+//   - A pointer to a map (*map[string]any), which will be overwritten with the custom claims.
+//   - A pointer to a struct (*T), which will be populated using its "json" struct tags.
+//
+// See ExampleClient_AuthenticateWithClaims_map, ExampleClient_AuthenticateWithClaims_struct for
+// examples.
 func (c *SessionsClient) AuthenticateWithClaims(
 	ctx context.Context,
 	body *sessions.AuthenticateParams,

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
@@ -18,6 +17,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/stytchauth/stytch-go/v12/stytch"
 	"github.com/stytchauth/stytch-go/v12/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v12/stytch/shared"
 	"github.com/stytchauth/stytch-go/v12/stytch/stytcherror"
 )
 
@@ -338,30 +338,12 @@ func (c *SessionsClient) AuthenticateJWTLocal(
 
 	// Remove all the reserved claims that are already present in staticClaims.
 	for key := range customClaims {
-		if reservedClaim(key) {
+		if shared.ReservedClaim(key) {
 			delete(customClaims, key)
 		}
 	}
 
 	return marshalJWTIntoSession(staticClaims, customClaims)
-}
-
-// reservedClaim returns true if the key is reserved by the JWT standard or the Stytch platform.
-func reservedClaim(key string) bool {
-	// Reserved claims
-	switch key {
-	case
-		"iss",
-		"aud",
-		"sub",
-		"iat",
-		"nbf",
-		"exp":
-		return true
-	}
-
-	// Stytch-specific claims are scoped by a URL prefix.
-	return strings.HasPrefix(key, "https://stytch.com/")
 }
 
 func marshalJWTIntoSession(claims sessions.Claims, customClaims map[string]any) (*sessions.Session, error) {

--- a/stytch/consumer/sessions_test.go
+++ b/stytch/consumer/sessions_test.go
@@ -209,6 +209,162 @@ func TestAuthenticateJWTLocal(t *testing.T) {
 	})
 }
 
+func TestAuthenticateJWTWithClaims(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/sessions/authenticate" {
+			// There are  many other fields in this response, but these are the only ones we need
+			// for this test.
+			_, _ = w.Write([]byte(`{
+			  "session": {
+			    "expires_at": "2022-06-29T19:53:48Z",
+			    "last_accessed_at": "2022-06-29T17:54:13Z",
+			    "session_id": "session-test-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+			    "started_at": "2022-06-29T17:53:48Z",
+			    "user_id": "user-test-00000000-0000-0000-0000-000000000000",
+
+			    "custom_claims": {
+			      "https://my-app.example.net/custom-claim": {
+			        "number": 1,
+			        "array": [1, "foo", null],
+			        "nested": {
+			          "data": "here"
+			        }
+			      }
+			    }
+			  }
+			}`))
+			return
+		}
+
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+	}))
+
+	client := &stytch.DefaultClient{
+		Config: &config.Config{
+			Env:       config.EnvTest,
+			BaseURI:   config.BaseURI(srv.URL),
+			ProjectID: "project-test-00000000-0000-0000-0000-000000000000",
+			Secret:    "secret-test-11111111-1111-1111-1111-111111111111",
+		},
+		HTTPClient: srv.Client(),
+	}
+
+	key := rsaKey(t)
+	keyID := "jwk-test-22222222-2222-2222-2222-222222222222"
+	jwks := keyfunc.NewGiven(map[string]keyfunc.GivenKey{
+		keyID: keyfunc.NewGivenRSA(&key.PublicKey, keyfunc.GivenKeyOptions{Algorithm: "RS256"}),
+	})
+
+	sessionClient := consumer.NewSessionsClient(client, jwks)
+
+	expectedClaims := map[string]any{
+		"https://my-app.example.net/custom-claim": map[string]any{
+			// Remember that numbers without specified types unmarshal as float64.
+			"number": float64(1),
+			"array":  []interface{}{float64(1), "foo", nil},
+			"nested": map[string]any{
+				"data": "here",
+			},
+		},
+	}
+
+	t.Run("populate claims map", func(t *testing.T) {
+		iat := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+		exp := iat.Add(5 * time.Minute)
+
+		token := signJWT(t, keyID, key, sandboxClaimsCustom(t, iat, exp, expectedClaims))
+
+		claims := make(map[string]any)
+		resp, err := sessionClient.AuthenticateJWTWithClaims(
+			context.Background(),
+			10*time.Minute,
+			&sessions.AuthenticateParams{SessionJWT: token},
+			claims,
+		)
+		require.NoError(t, err)
+
+		assert.Equal(t, expectedClaims, claims)
+		assert.Equal(t, expectedClaims, resp.Session.CustomClaims)
+	})
+
+	t.Run("skip populating a nil map", func(t *testing.T) {
+		iat := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+		exp := iat.Add(5 * time.Minute)
+
+		expected := map[string]any{"special": "val"}
+		token := signJWT(t, keyID, key, sandboxClaimsCustom(t, iat, exp, expected))
+
+		var claims map[string]any
+		assert.NotPanics(t, func() {
+			resp, err := sessionClient.AuthenticateJWTWithClaims(
+				context.Background(),
+				10*time.Minute,
+				&sessions.AuthenticateParams{SessionJWT: token},
+				claims,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, expected, resp.Session.CustomClaims)
+		})
+		assert.Empty(t, claims)
+	})
+
+	t.Run("send remote request if needed", func(t *testing.T) {
+		iat := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+		exp := iat.Add(5 * time.Minute)
+
+		token := signJWT(t, keyID, key, sandboxClaimsCustom(t, iat, exp, expectedClaims))
+
+		claims := make(map[string]any)
+		resp, err := sessionClient.AuthenticateJWTWithClaims(
+			context.Background(),
+			time.Nanosecond,
+			&sessions.AuthenticateParams{SessionJWT: token},
+			claims,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, expectedClaims, resp.Session.CustomClaims)
+		assert.Equal(t, expectedClaims, claims)
+	})
+
+	t.Run("send remote request if forced, skip claims", func(t *testing.T) {
+		iat := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+		exp := iat.Add(5 * time.Minute)
+
+		token := signJWT(t, keyID, key, sandboxClaimsCustom(t, iat, exp, expectedClaims))
+
+		var claims map[string]any
+		assert.NotPanics(t, func() {
+			resp, err := sessionClient.AuthenticateJWTWithClaims(
+				context.Background(),
+				0,
+				&sessions.AuthenticateParams{SessionJWT: token},
+				claims,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, expectedClaims, resp.Session.CustomClaims)
+		})
+		assert.Empty(t, claims)
+	})
+
+	t.Run("send remote request if forced, populate claims", func(t *testing.T) {
+		iat := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+		exp := iat.Add(5 * time.Minute)
+
+		token := signJWT(t, keyID, key, sandboxClaimsCustom(t, iat, exp, expectedClaims))
+
+		claims := make(map[string]any)
+		resp, err := sessionClient.AuthenticateJWTWithClaims(
+			context.Background(),
+			0,
+			&sessions.AuthenticateParams{SessionJWT: token},
+			claims,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, expectedClaims, resp.Session.CustomClaims)
+		assert.Equal(t, expectedClaims, claims)
+	})
+}
+
 func TestAuthenticateWithClaims(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Handle the async JWKS fetch.

--- a/stytch/shared/jwt.go
+++ b/stytch/shared/jwt.go
@@ -1,0 +1,21 @@
+package shared
+
+import "strings"
+
+// ReservedClaim returns true if the key is reserved by the JWT standard or the Stytch platform.
+func ReservedClaim(key string) bool {
+	// Standard claims
+	switch key {
+	case
+		"iss",
+		"aud",
+		"sub",
+		"iat",
+		"nbf",
+		"exp":
+		return true
+	}
+
+	// Stytch-specific claims are scoped by a URL prefix.
+	return strings.HasPrefix(key, "https://stytch.com/")
+}

--- a/stytch/shared/jwt_test.go
+++ b/stytch/shared/jwt_test.go
@@ -1,0 +1,35 @@
+package shared_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stytchauth/stytch-go/v12/stytch/shared"
+)
+
+func TestReservedClaim(t *testing.T) {
+	testcases := map[string]bool{
+		// Standard claims
+		"iss": true,
+		"aud": true,
+		"sub": true,
+		"iat": true,
+		"nbf": true,
+		"exp": true,
+
+		// Stytch claims
+		"https://stytch.com/session":                true,
+		"https://stytch.com/organization":           true,
+		"https://stytch.com/some/hypothetical/path": true,
+
+		// Custom claims
+		"any":                         false,
+		"https://example.com/session": false,
+	}
+
+	for key, expected := range testcases {
+		t.Run(key, func(t *testing.T) {
+			assert.Equal(t, expected, shared.ReservedClaim(key))
+		})
+	}
+}


### PR DESCRIPTION
This fixes a bug that causes custom claims to be omitted from the returned Session value when authenticating a Session JWT locally. This affects `AuthenticateJWTLocal` directly. The change also applies to `AuthenticateJWT` and `AuthenticateJWTWithClaims` which prefer using it for local validation over sending a request to the API.

The fix is to separate the app's custom claims from the standard and Stytch-specific JWT claims. This is complicated slightly by the fact that the Stytch session claim is a large, complex struct and custom claims are effectively unconstrained.

I see two options:
1. Parse the claims into `jwt.MapClaims` and split the claims by key into known and unknown sets.
2. Parse the claims twice: once into `sessions.SessionClaim` and once into `jwt.MapClaims` (and then clean the map).

I tried using `mapstructure` to implement (1) like we do for `custom_claims` fields elsewhere. This is slightly different because we're working with the whole set of JWT claims and not just a map of known-custom ones. I ran into trouble when it tried to "unpack" the timestamp strings into their `*time.Time` fields (specifically for authentication factors). I briefly looked for a decoder option to handle this, but I didn't see one see one (let me know if you do!).

So this PR implements (2). This only supports viewing the custom claims as `map[string]any` to avoid changing any of the function signatures. In the future, it may make sense to align the `AuthenticateJWTWithClaims` signature with `AuthenticateWithClaims` 

Except for a documentation update, all of the code I changed is within a `MANUAL` section. I'll see if I can get the doc updated by the generator for its next run.