### PR TITLE
Update docs and support set_email_verified

### DIFF
--- a/stytch/b2b/discovery/organizations/types.go
+++ b/stytch/b2b/discovery/organizations/types.go
@@ -138,16 +138,16 @@ type CreateParams struct {
 	// [RBAC guide](https://stytch.com/docs/b2b/guides/rbac/role-assignment)
 	//   for more information about role assignment.
 	RBACEmailImplicitRoleAssignments []*organizations.EmailImplicitRoleAssignment `json:"rbac_email_implicit_role_assignments,omitempty"`
-	// MFAMethods: The setting that controls which mfa methods can be used by Members of an Organization. The
+	// MFAMethods: The setting that controls which MFA methods can be used by Members of an Organization. The
 	// accepted values are:
 	//
 	//   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
 	//
-	//   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+	//   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
 	// This setting does not apply to Members with `is_breakglass` set to `true`.
 	//
 	MFAMethods string `json:"mfa_methods,omitempty"`
-	// AllowedMFAMethods: An array of allowed mfa authentication methods. This list is enforced when
+	// AllowedMFAMethods: An array of allowed MFA authentication methods. This list is enforced when
 	// `mfa_methods` is set to `RESTRICTED`.
 	//   The list's accepted values are: `sms_otp` and `totp`.
 	//

--- a/stytch/b2b/organizations/members/types.go
+++ b/stytch/b2b/organizations/members/types.go
@@ -178,7 +178,7 @@ type UpdateParams struct {
 	// more details.
 	//
 	// If this field is provided and a session header is passed into the request, the Member Session must have
-	// permission to perform the `update.info.is-breakglass` action on the `stytch.member` Resource.
+	// permission to perform the `update.settings.is-breakglass` action on the `stytch.member` Resource.
 	IsBreakglass bool `json:"is_breakglass,omitempty"`
 	// MFAPhoneNumber: Sets the Member's phone number. Throws an error if the Member already has a phone
 	// number. To change the Member's phone number, use the

--- a/stytch/b2b/organizations/types.go
+++ b/stytch/b2b/organizations/types.go
@@ -101,16 +101,16 @@ type CreateParams struct {
 	// [RBAC guide](https://stytch.com/docs/b2b/guides/rbac/role-assignment)
 	//   for more information about role assignment.
 	RBACEmailImplicitRoleAssignments []*EmailImplicitRoleAssignment `json:"rbac_email_implicit_role_assignments,omitempty"`
-	// MFAMethods: The setting that controls which mfa methods can be used by Members of an Organization. The
+	// MFAMethods: The setting that controls which MFA methods can be used by Members of an Organization. The
 	// accepted values are:
 	//
 	//   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
 	//
-	//   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+	//   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
 	// This setting does not apply to Members with `is_breakglass` set to `true`.
 	//
 	MFAMethods string `json:"mfa_methods,omitempty"`
-	// AllowedMFAMethods: An array of allowed mfa authentication methods. This list is enforced when
+	// AllowedMFAMethods: An array of allowed MFA authentication methods. This list is enforced when
 	// `mfa_methods` is set to `RESTRICTED`.
 	//   The list's accepted values are: `sms_otp` and `totp`.
 	//
@@ -410,16 +410,16 @@ type Organization struct {
 	// [RBAC guide](https://stytch.com/docs/b2b/guides/rbac/role-assignment)
 	//   for more information about role assignment.
 	RBACEmailImplicitRoleAssignments []EmailImplicitRoleAssignment `json:"rbac_email_implicit_role_assignments,omitempty"`
-	// MFAMethods: The setting that controls which mfa methods can be used by Members of an Organization. The
+	// MFAMethods: The setting that controls which MFA methods can be used by Members of an Organization. The
 	// accepted values are:
 	//
 	//   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
 	//
-	//   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+	//   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
 	// This setting does not apply to Members with `is_breakglass` set to `true`.
 	//
 	MFAMethods string `json:"mfa_methods,omitempty"`
-	// AllowedMFAMethods: An array of allowed mfa authentication methods. This list is enforced when
+	// AllowedMFAMethods: An array of allowed MFA authentication methods. This list is enforced when
 	// `mfa_methods` is set to `RESTRICTED`.
 	//   The list's accepted values are: `sms_otp` and `totp`.
 	//
@@ -625,20 +625,20 @@ type UpdateParams struct {
 	// If this field is provided and a session header is passed into the request, the Member Session must have
 	// permission to perform the `update.settings.implicit-roles` action on the `stytch.organization` Resource.
 	RBACEmailImplicitRoleAssignments []string `json:"rbac_email_implicit_role_assignments,omitempty"`
-	// MFAMethods: The setting that controls which mfa methods can be used by Members of an Organization. The
+	// MFAMethods: The setting that controls which MFA methods can be used by Members of an Organization. The
 	// accepted values are:
 	//
 	//   `ALL_ALLOWED` – the default setting which allows all authentication methods to be used.
 	//
-	//   `RESTRICTED` – only methods that comply with `allowed_auth_methods` can be used for authentication.
+	//   `RESTRICTED` – only methods that comply with `allowed_mfa_methods` can be used for authentication.
 	// This setting does not apply to Members with `is_breakglass` set to `true`.
 	//
 	//
 	// If this field is provided and a session header is passed into the request, the Member Session must have
-	// permission to perform the `update.settings.allowed-auth-methods` action on the `stytch.organization`
+	// permission to perform the `update.settings.allowed-mfa-methods` action on the `stytch.organization`
 	// Resource.
 	MFAMethods string `json:"mfa_methods,omitempty"`
-	// AllowedMFAMethods: An array of allowed mfa authentication methods. This list is enforced when
+	// AllowedMFAMethods: An array of allowed MFA authentication methods. This list is enforced when
 	// `mfa_methods` is set to `RESTRICTED`.
 	//   The list's accepted values are: `sms_otp` and `totp`.
 	//

--- a/stytch/b2b/rbac.go
+++ b/stytch/b2b/rbac.go
@@ -27,10 +27,11 @@ func NewRBACClient(c stytch.Client) *RBACClient {
 // Policy: Get the active RBAC Policy for your current Stytch Project. An RBAC Policy is the canonical
 // document that stores all defined Resources and Roles within your RBAC permissioning model.
 //
-// When using the backend SDKs, the RBAC Policy will automatically be loaded and refreshed in the
-// background to allow for local evaluations, eliminating the need for an extra request to Stytch.
+// When using the backend SDKs, the RBAC Policy will be cached to allow for local evaluations, eliminating
+// the need for an extra request to Stytch. The policy will be refreshed if an authorization check is
+// requested and the RBAC policy was last updated more than 5 minutes ago.
 //
-// Resources and Roles can be created and managed within the [Dashboard](/dashboard). Additionally,
+// Resources and Roles can be created and managed within the [Dashboard](/dashboard/rbac). Additionally,
 // [Role assignment](https://stytch.com/docs/b2b/guides/rbac/role-assignment) can be programmatically
 // managed through certain Stytch API endpoints.
 //

--- a/stytch/b2b/rbac/types.go
+++ b/stytch/b2b/rbac/types.go
@@ -17,21 +17,116 @@ type Policy struct {
 // PolicyParams: Request type for `RBAC.Policy`.
 type PolicyParams struct{}
 
+// PolicyResource:
 type PolicyResource struct {
-	ResourceID  string   `json:"resource_id,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Actions     []string `json:"actions,omitempty"`
+	// ResourceID: A unique identifier of the RBAC Resource, provided by the developer and intended to be
+	// human-readable.
+	//
+	//   A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch
+	// default Resources with reserved  `resource_id`s. These include:
+	//
+	//   * `stytch.organization`
+	//   * `stytch.member`
+	//   * `stytch.sso`
+	//   * `stytch.self`
+	//
+	//   Check out the
+	// [guide on Stytch default Resources](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults) for a more
+	// detailed explanation.
+	//
+	//
+	ResourceID string `json:"resource_id,omitempty"`
+	// Description: The description of the RBAC Resource.
+	Description string `json:"description,omitempty"`
+	// Actions: A list of all possible actions for a provided Resource.
+	//
+	//   Reserved `actions` that are predefined by Stytch include:
+	//
+	//   * `*`
+	//   * For the `stytch.organization` Resource:
+	//     * `update.info.name`
+	//     * `update.info.slug`
+	//     * `update.info.untrusted_metadata`
+	//     * `update.info.email_jit_provisioning`
+	//     * `update.info.logo_url`
+	//     * `update.info.email_invites`
+	//     * `update.info.allowed_domains`
+	//     * `update.info.default_sso_connection`
+	//     * `update.info.sso_jit_provisioning`
+	//     * `update.info.mfa_policy`
+	//     * `update.info.implicit_roles`
+	//     * `delete`
+	//   * For the `stytch.member` Resource:
+	//     * `create`
+	//     * `update.info.name`
+	//     * `update.info.untrusted_metadata`
+	//     * `update.info.mfa-phone`
+	//     * `update.info.delete.mfa-phone`
+	//     * `update.settings.is-breakglass`
+	//     * `update.settings.mfa_enrolled`
+	//     * `update.settings.roles`
+	//     * `search`
+	//     * `delete`
+	//   * For the `stytch.sso` Resource:
+	//     * `create`
+	//     * `update`
+	//     * `delete`
+	//   * For the `stytch.self` Resource:
+	//     * `update.info.name`
+	//     * `update.info.untrusted_metadata`
+	//     * `update.info.mfa-phone`
+	//     * `update.info.delete.mfa-phone`
+	//     * `update.info.delete.password`
+	//     * `update.settings.mfa_enrolled`
+	//     * `delete`
+	//
+	Actions []string `json:"actions,omitempty"`
 }
 
+// PolicyRole:
 type PolicyRole struct {
-	RoleID      string                 `json:"role_id,omitempty"`
-	Description string                 `json:"description,omitempty"`
+	// RoleID: The unique identifier of the RBAC Role, provided by the developer and intended to be
+	// human-readable.
+	//
+	//   Reserved `role_id`s that are predefined by Stytch include:
+	//
+	//   * `stytch_member`
+	//   * `stytch_admin`
+	//
+	//   Check out the [guide on Stytch default Roles](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults)
+	// for a more detailed explanation.
+	//
+	//
+	RoleID string `json:"role_id,omitempty"`
+	// Description: The description of the RBAC Role.
+	Description string `json:"description,omitempty"`
+	// Permissions: A list of permissions that link a
+	// [Resource](https://stytch.com/docs/b2b/api/rbac-resource-object) to a list of actions.
 	Permissions []PolicyRolePermission `json:"permissions,omitempty"`
 }
 
+// PolicyRolePermission:
 type PolicyRolePermission struct {
-	ResourceID string   `json:"resource_id,omitempty"`
-	Actions    []string `json:"actions,omitempty"`
+	// ResourceID: A unique identifier of the RBAC Resource, provided by the developer and intended to be
+	// human-readable.
+	//
+	//   A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch
+	// default Resources with reserved  `resource_id`s. These include:
+	//
+	//   * `stytch.organization`
+	//   * `stytch.member`
+	//   * `stytch.sso`
+	//   * `stytch.self`
+	//
+	//   Check out the
+	// [guide on Stytch default Resources](https://stytch.com/docs/b2b/guides/rbac/stytch-defaults) for a more
+	// detailed explanation.
+	//
+	//
+	ResourceID string `json:"resource_id,omitempty"`
+	// Actions: A list of permitted actions the Role is authorized to take with the provided Resource. You can
+	// use `*` as a wildcard to grant a Role permission to use all possible actions related to the Resource.
+	Actions []string `json:"actions,omitempty"`
 }
 
 // PolicyResponse: Response type for `RBAC.Policy`.
@@ -45,7 +140,7 @@ type PolicyResponse struct {
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
 	// Policy: The RBAC Policy document that contains all defined Roles and Resources – which are managed in
-	// the [Dashboard](/dashboard). Read more about these entities and how they work in our
+	// the [Dashboard](/dashboard/rbac). Read more about these entities and how they work in our
 	// [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview).
 	Policy *Policy `json:"policy,omitempty"`
 }

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "12.1.0"
+const APIVersion = "12.2.0"

--- a/stytch/consumer/passwords/types.go
+++ b/stytch/consumer/passwords/types.go
@@ -169,6 +169,13 @@ type MigrateParams struct {
 	// **cannot be used to store critical information.** See the
 	// [Metadata](https://stytch.com/docs/api/metadata) reference for complete field behavior details.
 	UntrustedMetadata map[string]any `json:"untrusted_metadata,omitempty"`
+	// SetEmailVerified: Whether to set the user's email as verified. This is a dangerous field. Incorrect use
+	// may lead to users getting erroneously
+	//                 deduplicated into one user object. This flag should only be set if you can attest that
+	// the user owns the email address in question.
+	//                 Access to this field is restricted. To enable it, please send us a note at
+	// support@stytch.com.
+	SetEmailVerified bool `json:"set_email_verified,omitempty"`
 	// Name: The name of the user. Each field in the name object is optional.
 	Name *users.Name `json:"name,omitempty"`
 }


### PR DESCRIPTION
1. Docs updates
2. Adds support for `set_email_verified` in passwords/migrate