### PR TITLE
Change MicrosoftParams to ProviderInformationParams

### DIFF
--- a/stytch/b2b/organizations/members/oauthproviders/types.go
+++ b/stytch/b2b/organizations/members/oauthproviders/types.go
@@ -6,8 +6,8 @@ package oauthproviders
 // or your changes may be overwritten later!
 // !!!
 
-// MicrosoftParams: Request type for `OAuthProviders.Google`, `OAuthProviders.Microsoft`.
-type MicrosoftParams struct {
+// ProviderInformationParams: Request type for `OAuthProviders.Google`, `OAuthProviders.Microsoft`.
+type ProviderInformationParams struct {
 	// OrganizationID: Globally unique UUID that identifies a specific Organization. The `organization_id` is
 	// critical to perform operations on an Organization, so be sure to preserve this value.
 	OrganizationID string `json:"organization_id,omitempty"`

--- a/stytch/b2b/organizations_members_oauthproviders.go
+++ b/stytch/b2b/organizations_members_oauthproviders.go
@@ -35,7 +35,7 @@ func NewOrganizationsMembersOAuthProvidersClient(c stytch.Client) *Organizations
 // [Start Google OAuth flow](https://stytch.com/docs/b2b/api/oauth-google-start) endpoint.
 func (c *OrganizationsMembersOAuthProvidersClient) Google(
 	ctx context.Context,
-	body *oauthproviders.MicrosoftParams,
+	body *oauthproviders.ProviderInformationParams,
 ) (*oauthproviders.GoogleResponse, error) {
 	queryParams := make(map[string]string)
 	if body != nil {
@@ -68,7 +68,7 @@ func (c *OrganizationsMembersOAuthProvidersClient) Google(
 // access token automatically.
 func (c *OrganizationsMembersOAuthProvidersClient) Microsoft(
 	ctx context.Context,
-	body *oauthproviders.MicrosoftParams,
+	body *oauthproviders.ProviderInformationParams,
 ) (*oauthproviders.MicrosoftResponse, error) {
 	queryParams := make(map[string]string)
 	if body != nil {

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "12.5.1"
+const APIVersion = "13.0.0"


### PR DESCRIPTION
This is a major version bump because we have a breaking change: we need to rename `MicrosoftParams` to `ProviderInformationParams`, since it's used for more than just Microsoft OAuth.