### PR TITLE
Fixes #177 - use pointer to roles for Member.Update

### DIFF
--- a/stytch/b2b/organizations/members/types.go
+++ b/stytch/b2b/organizations/members/types.go
@@ -215,7 +215,7 @@ type UpdateParams struct {
 	//
 	// If this field is provided and a session header is passed into the request, the Member Session must have
 	// permission to perform the `update.settings.roles` action on the `stytch.member` Resource.
-	Roles []string `json:"roles,omitempty"`
+	Roles *[]string `json:"roles,omitempty"`
 	// PreserveExistingSessions: Whether to preserve existing sessions when explicit Roles that are revoked are
 	// also implicitly assigned
 	//   by SSO connection or SSO group. Defaults to `false` - that is, existing Member Sessions that contain

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "13.4.0"
+const APIVersion = "14.0.0"


### PR DESCRIPTION
This has to be a MAJOR update since we're breaking an API, but otherwise this is a really straightforward change. We've also added support in the codegen backend to support this more easily in the future.