### PR TITLE
Support wildcard scopes in M2M auth

### DIFF
--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "14.2.0"
+const APIVersion = "14.3.0"

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "14.3.0"
+const APIVersion = "15.1.0"

--- a/stytch/consumer/m2m.go
+++ b/stytch/consumer/m2m.go
@@ -174,7 +174,15 @@ func (c *M2MClient) AuthenticateToken(
 	}
 
 	hasScopes := strings.Split(scope, " ")
-	err = shared.PerformM2MAuthorizationCheck(hasScopes, req.RequiredScopes)
+	var authorizationFunc m2m.ScopeAuthorizationFunc = shared.PerformM2MAuthorizationCheck
+	if req.AuthorizationFunc != nil {
+		authorizationFunc = *req.AuthorizationFunc
+	}
+
+	err = authorizationFunc(m2m.ScopeAuthorizationFuncParams{
+		HasScopes:      hasScopes,
+		RequiredScopes: req.RequiredScopes,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/stytch/consumer/m2m/types.go
+++ b/stytch/consumer/m2m/types.go
@@ -136,10 +136,7 @@ type TokenResponse struct {
 	TokenType string `json:"token_type"`
 }
 
-var (
-	ErrJWTTooOld    = errors.New("JWT too old")
-	ErrMissingScope = errors.New("missing requested scope")
-)
+var ErrJWTTooOld = errors.New("JWT too old")
 
 type AuthenticateTokenParams struct {
 	AccessToken    string

--- a/stytch/consumer/m2m/types.go
+++ b/stytch/consumer/m2m/types.go
@@ -118,11 +118,11 @@ const (
 // ADDIMPORT: "github.com/golang-jwt/jwt/v5"
 
 type TokenParams struct {
-	// The ID of the client.
+	// ClientID is the ID of the client.
 	ClientID string
-	// The secret of the client.
+	// ClientSecret is the secret of the client.
 	ClientSecret string
-	// An array scopes requested. If omitted, all scopes assigned to the client will be returned.
+	// Scopes is an array scopes requested. If omitted, all scopes assigned to the client will be returned.
 	Scopes []string
 }
 
@@ -138,18 +138,29 @@ type TokenResponse struct {
 
 var ErrJWTTooOld = errors.New("JWT too old")
 
+type ScopeAuthorizationFuncParams struct {
+	HasScopes      []string
+	RequiredScopes []string
+}
+
+type ScopeAuthorizationFunc func(ScopeAuthorizationFuncParams) error
+
 type AuthenticateTokenParams struct {
 	AccessToken    string
 	RequiredScopes []string
 	MaxTokenAge    time.Duration
+	// AuthorizationFunc is a custom function to authorize the client's scopes. If omitted, the default function will be used.
+	// The default function assumes scopes are either direct string matches or written in the form "action:resource".
+	// See the documentation for `shared.PerformAuthorizationCheck` for more information.
+	AuthorizationFunc *ScopeAuthorizationFunc
 }
 
 type AuthenticateTokenResponse struct {
-	// An array of scopes granted to the token holder.
+	// Scopes is an array of scopes granted to the token holder.
 	Scopes []string
-	// The ID of the client that was issued the token
+	// ClientID is the ID of the client that was issued the token
 	ClientID string
-	// A map of custom claims present in the token
+	// CustomClaims is a map of custom claims present in the token
 	CustomClaims map[string]any
 }
 

--- a/stytch/consumer/m2m_test.go
+++ b/stytch/consumer/m2m_test.go
@@ -186,7 +186,7 @@ func TestM2MClient_AuthenticateToken(t *testing.T) {
 			AccessToken:    token,
 			RequiredScopes: []string{"write:users"},
 		})
-		assert.ErrorIs(t, err, m2m.ErrMissingScope)
+		assert.ErrorIs(t, err, stytcherror.NewM2MPermissionError())
 		assert.Nil(t, s)
 	})
 

--- a/stytch/shared/m2m_authorization.go
+++ b/stytch/shared/m2m_authorization.go
@@ -3,17 +3,15 @@ package shared
 import (
 	"strings"
 
+	"github.com/stytchauth/stytch-go/v15/stytch/consumer/m2m"
 	"github.com/stytchauth/stytch-go/v15/stytch/stytcherror"
 )
 
-func PerformM2MAuthorizationCheck(
-	hasScopes []string,
-	requiredScopes []string,
-) error {
+func PerformM2MAuthorizationCheck(params m2m.ScopeAuthorizationFuncParams) error {
 	clientScopes := map[string][]string{}
-	for _, scope := range hasScopes {
+	for _, scope := range params.HasScopes {
 		action := scope
-		resource := "*"
+		resource := "-"
 		if strings.Contains(scope, ":") {
 			parts := strings.SplitN(scope, ":", 2)
 			action = parts[0]
@@ -22,9 +20,9 @@ func PerformM2MAuthorizationCheck(
 		clientScopes[action] = append(clientScopes[action], resource)
 	}
 
-	for _, requiredScope := range requiredScopes {
+	for _, requiredScope := range params.RequiredScopes {
 		requiredAction := requiredScope
-		requiredResource := "*"
+		requiredResource := "-"
 		if strings.Contains(requiredScope, ":") {
 			parts := strings.SplitN(requiredScope, ":", 2)
 			requiredAction = parts[0]

--- a/stytch/shared/m2m_authorization.go
+++ b/stytch/shared/m2m_authorization.go
@@ -1,0 +1,51 @@
+package shared
+
+import (
+	"strings"
+
+	"github.com/stytchauth/stytch-go/v15/stytch/stytcherror"
+)
+
+func PerformM2MAuthorizationCheck(
+	hasScopes []string,
+	requiredScopes []string,
+) error {
+	clientScopes := map[string][]string{}
+	for _, scope := range hasScopes {
+		action := scope
+		resource := "*"
+		if strings.Contains(scope, ":") {
+			parts := strings.SplitN(scope, ":", 2)
+			action = parts[0]
+			resource = parts[1]
+		}
+		clientScopes[action] = append(clientScopes[action], resource)
+	}
+
+	for _, requiredScope := range requiredScopes {
+		requiredAction := requiredScope
+		requiredResource := "*"
+		if strings.Contains(requiredScope, ":") {
+			parts := strings.SplitN(requiredScope, ":", 2)
+			requiredAction = parts[0]
+			requiredResource = parts[1]
+		}
+		resources, ok := clientScopes[requiredAction]
+		if !ok {
+			return stytcherror.NewM2MPermissionError()
+		}
+
+		found := false
+		for _, resource := range resources {
+			if resource == "*" || resource == requiredResource {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return stytcherror.NewM2MPermissionError()
+		}
+	}
+	return nil
+}

--- a/stytch/shared/m2m_authorization_test.go
+++ b/stytch/shared/m2m_authorization_test.go
@@ -1,0 +1,62 @@
+package shared_test
+
+import (
+	"testing"
+
+	"github.com/stytchauth/stytch-go/v15/stytch/shared"
+)
+
+func TestPerformM2MAuthorizationCheck(t *testing.T) {
+	tests := []struct {
+		name        string
+		has         []string
+		needs       []string
+		expectError bool
+	}{
+		{
+			name:        "basic",
+			has:         []string{"read:users", "write:users"},
+			needs:       []string{"read:users"},
+			expectError: false,
+		},
+		{
+			name:        "multiple required scopes",
+			has:         []string{"read:users", "write:users", "read:books"},
+			needs:       []string{"read:users", "read:books"},
+			expectError: false,
+		},
+		{
+			name:        "simple scopes",
+			has:         []string{"read_users", "write_users"},
+			needs:       []string{"read_users"},
+			expectError: false,
+		},
+		{
+			name:        "wildcard resource",
+			has:         []string{"read:*", "write:*"},
+			needs:       []string{"read:users"},
+			expectError: false,
+		},
+		{
+			name:        "missing required scope",
+			has:         []string{"read:users"},
+			needs:       []string{"write:users"},
+			expectError: true,
+		},
+		{
+			name:        "missing required scope with wildcard",
+			has:         []string{"read:users", "write:*"},
+			needs:       []string{"delete:books"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := shared.PerformM2MAuthorizationCheck(tt.has, tt.needs)
+			if (err != nil) != tt.expectError {
+				t.Errorf("PerformM2MAuthorizationCheck(%v, %v) error = %v, expectError %v", tt.has, tt.needs, err, tt.expectError)
+			}
+		})
+	}
+}

--- a/stytch/shared/m2m_authorization_test.go
+++ b/stytch/shared/m2m_authorization_test.go
@@ -3,6 +3,7 @@ package shared_test
 import (
 	"testing"
 
+	"github.com/stytchauth/stytch-go/v15/stytch/consumer/m2m"
 	"github.com/stytchauth/stytch-go/v15/stytch/shared"
 )
 
@@ -49,11 +50,26 @@ func TestPerformM2MAuthorizationCheck(t *testing.T) {
 			needs:       []string{"delete:books"},
 			expectError: true,
 		},
+		{
+			name:        "has simple scope and wants specific scope",
+			has:         []string{"read"},
+			needs:       []string{"read:users"},
+			expectError: true,
+		},
+		{
+			name:        "has specific scope and wants simple scope",
+			has:         []string{"read:users"},
+			needs:       []string{"read"},
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := shared.PerformM2MAuthorizationCheck(tt.has, tt.needs)
+			err := shared.PerformM2MAuthorizationCheck(m2m.ScopeAuthorizationFuncParams{
+				HasScopes:      tt.has,
+				RequiredScopes: tt.needs,
+			})
 			if (err != nil) != tt.expectError {
 				t.Errorf("PerformM2MAuthorizationCheck(%v, %v) error = %v, expectError %v", tt.has, tt.needs, err, tt.expectError)
 			}

--- a/stytch/stytcherror/stytcherror.go
+++ b/stytch/stytcherror/stytcherror.go
@@ -97,4 +97,14 @@ func NewPermissionError() error {
 	}
 }
 
+func NewM2MPermissionError() error {
+	msg := "The Client is not authorized to perform the requested action on that resource."
+	return Error{
+		StatusCode:   403,
+		ErrorType:    "m2m_authorization_error",
+		ErrorMessage: Message(msg + ", v" + config.APIVersion),
+		ErrorURL:     "https://stytch.com/docs/api/errors/403",
+	}
+}
+
 var ErrJWKSNotInitialized = errors.New("JWKS not initialized")


### PR DESCRIPTION
This PR adds support for wildcard scopes in M2M auth.
This means that an M2M client can have a scope like `read:*` and if given a required scope of `read:foo`, authentication will be allowed.

This does *not* affect "simple" scopes like `read` or `read_users` -- only scopes with a separating `:` are supported.

Furthermore, the assumption is that the scopes will be given as `action:resource`, though it is technically possible to assign in a different way like `users:read`, though in that case, a scope of `users:*` would **not** match a required scope of `read:users`. But as long as an application is consistent, this would be allowed.

Furthermore, a scope of just `*` does **not** get interpreted as an "omniscient" client -- instead, this is seen as the literal character `*` and gets matched similarly to `read_users` as mentioned above.