### PR TITLE
Change ChainID to string

### DIFF
--- a/stytch/b2b/organizations/types.go
+++ b/stytch/b2b/organizations/types.go
@@ -330,6 +330,16 @@ type MemberRoleSource struct {
 	//   argument to the [Update SAML connection](https://stytch.com/docs/b2b/api/update-saml-connection)
 	// endpoint.
 	//
+	//     `scim_connection_group` – an implicit Role granted by the Member's SCIM connection and group. If the
+	// Member has
+	//   a SCIM Member registration with the given connection, and belongs to a specific group within the IdP,
+	// this role assignment will appear in the list.
+	//
+	//   SCIM group implicit role assignments can be updated by passing in the
+	// `scim_group_implicit_role_assignments`
+	//   argument to the [Update SCIM connection](https://stytch.com/docs/b2b/api/update-scim-connection)
+	// endpoint.
+	//
 	Type string `json:"type,omitempty"`
 	// Details: An object containing additional metadata about the source assignment. The fields will vary
 	// depending
@@ -343,6 +353,9 @@ type MemberRoleSource struct {
 	//
 	//   `sso_connection_group` – will contain the `connection_id` of the SAML connection and the name of the
 	// `group`
+	//   that granted the assignment.
+	//
+	//   `scim_connection_group` – will contain the `connection_id` of the SAML connection and the `group_id`
 	//   that granted the assignment.
 	//
 	Details map[string]any `json:"details,omitempty"`

--- a/stytch/b2b/scim/connection/types.go
+++ b/stytch/b2b/scim/connection/types.go
@@ -95,7 +95,7 @@ type UpdateParams struct {
 	DisplayName      string                        `json:"display_name,omitempty"`
 	IdentityProvider UpdateRequestIdentityProvider `json:"identity_provider,omitempty"`
 	// SCIMGroupImplicitRoleAssignments: An array of SCIM group implicit role assignments. Each object in the
-	// array must contain a `group` and a `role_id`.
+	// array must contain a `group_id` and a `role_id`.
 	SCIMGroupImplicitRoleAssignments []*scim.SCIMGroupImplicitRoleAssignments `json:"scim_group_implicit_role_assignments,omitempty"`
 }
 

--- a/stytch/b2b/scim/types.go
+++ b/stytch/b2b/scim/types.go
@@ -41,6 +41,11 @@ type Group struct {
 	Display string `json:"display,omitempty"`
 }
 
+type IMs struct {
+	Value string `json:"value,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
 type Manager struct {
 	Value       string `json:"value,omitempty"`
 	Ref         string `json:"ref,omitempty"`
@@ -79,6 +84,7 @@ type SCIMAttributes struct {
 	Emails              []Email              `json:"emails,omitempty"`
 	PhoneNumbers        []PhoneNumber        `json:"phone_numbers,omitempty"`
 	Addresses           []Address            `json:"addresses,omitempty"`
+	Ims                 []IMs                `json:"ims,omitempty"`
 	Name                *Name                `json:"name,omitempty"`
 	EnterpriseExtension *EnterpriseExtension `json:"enterprise_extension,omitempty"`
 }
@@ -139,7 +145,8 @@ type SCIMGroup struct {
 // SCIMGroupImplicitRoleAssignments:
 type SCIMGroupImplicitRoleAssignments struct {
 	// RoleID: The ID of the role.
-	RoleID    string `json:"role_id,omitempty"`
+	RoleID string `json:"role_id,omitempty"`
+	// GroupID: The ID of the group.
 	GroupID   string `json:"group_id,omitempty"`
 	GroupName string `json:"group_name,omitempty"`
 }

--- a/stytch/b2b/scim_connection.go
+++ b/stytch/b2b/scim_connection.go
@@ -249,7 +249,7 @@ func (c *SCIMConnectionClient) Create(
 	return &retVal, err
 }
 
-// Get SCIM Connections.
+// Get SCIM Connection.
 func (c *SCIMConnectionClient) Get(
 	ctx context.Context,
 	body *connection.GetParams,

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "15.3.0"
+const APIVersion = "15.4.0"

--- a/stytch/consumer/cryptowallets/types.go
+++ b/stytch/consumer/cryptowallets/types.go
@@ -80,9 +80,12 @@ type SIWEParams struct {
 	// Resources:  A list of information or references to information the user wishes to have resolved as part
 	// of authentication. Every resource must be an RFC 3986 URI.
 	Resources []string `json:"resources,omitempty"`
-	// ChainID: The EIP-155 Chain ID to which the session is bound. Defaults to 1.
-	ChainID uint32 `json:"chain_id,omitempty"`
-	// Statement: A human-readable ASCII assertion that the user will sign.
+	// ChainID: The EIP-155 Chain ID to which the session is bound. Defaults to 1. Must be the string
+	// representation of an integer between 1 and 9,223,372,036,854,775,771, inclusive.
+	ChainID string `json:"chain_id,omitempty"`
+	// Statement: A human-readable ASCII assertion that the user will sign. The statement may only include
+	// reserved, unreserved, or space characters according to RFC 3986 definitions, and must not contain other
+	// forms of whitespace such as newlines, tabs, and carriage returns.
 	Statement string `json:"statement,omitempty"`
 	// IssuedAt: The time when the message was generated. Defaults to the current time. All timestamps in our
 	// API conform to the RFC 3339 standard and are expressed in UTC, e.g. `2021-12-29T12:33:09Z`.
@@ -91,7 +94,8 @@ type SIWEParams struct {
 	// time. All timestamps in our API conform to the RFC 3339 standard and are expressed in UTC, e.g.
 	// `2021-12-29T12:33:09Z`.
 	NotBefore *time.Time `json:"not_before,omitempty"`
-	// MessageRequestID: A system-specific identifier that may be used to uniquely refer to the sign-in request.
+	// MessageRequestID: A system-specific identifier that may be used to uniquely refer to the sign-in
+	// request. The `message_request_id` must be a valid pchar according to RFC 3986 definitions.
 	MessageRequestID string `json:"message_request_id,omitempty"`
 }
 
@@ -149,7 +153,7 @@ type SIWEParamsResponse struct {
 	// URI: An RFC 3986 URI referring to the resource that is the subject of the signing.
 	URI string `json:"uri,omitempty"`
 	// ChainID: The EIP-155 Chain ID to which the session is bound.
-	ChainID uint32 `json:"chain_id,omitempty"`
+	ChainID string `json:"chain_id,omitempty"`
 	// Resources:  A list of information or references to information the user wishes to have resolved as part
 	// of authentication. Every resource must be an RFC 3986 URI.
 	Resources  []string `json:"resources,omitempty"`


### PR DESCRIPTION
Changes the SIWE `ChainID` type to a `string` rather than `uint32`. Since SIWE isn't released yet, I'm marking this as a minor version bump.