### PR TITLE
Use struct type for request params

### DIFF
--- a/stytch/b2b/discovery/types.go
+++ b/stytch/b2b/discovery/types.go
@@ -31,7 +31,8 @@ type DiscoveredOrganization struct {
 
 // Membership:
 type Membership struct {
-	// Type: Either `active_member`, `pending_member`, `invited_member`, or `eligible_to_join_by_email_domain`
+	// Type: Either `active_member`, `pending_member`, `invited_member`, `eligible_to_join_by_email_domain`, or
+	// `eligible_to_join_by_oauth_tenant`
 	Type string `json:"type,omitempty"`
 	// Details: An object containing additional metadata about the membership, if available.
 	Details map[string]any `json:"details,omitempty"`

--- a/stytch/b2b/discovery_intermediatesessions.go
+++ b/stytch/b2b/discovery_intermediatesessions.go
@@ -68,12 +68,14 @@ func (c *DiscoveryIntermediateSessionsClient) Exchange(
 	var retVal intermediatesessions.ExchangeResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/discovery/intermediate_sessions/exchange",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/discovery/intermediate_sessions/exchange",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/discovery_organizations.go
+++ b/stytch/b2b/discovery_organizations.go
@@ -66,12 +66,14 @@ func (c *DiscoveryOrganizationsClient) Create(
 	var retVal organizations.CreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/discovery/organizations/create",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/discovery/organizations/create",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -86,7 +88,7 @@ func (c *DiscoveryOrganizationsClient) Create(
 //
 // When an Intermediate Session is passed in, all relationship types - `active_member`, `pending_member`,
 // `invited_member`,
-// and `eligible_to_join_by_email_domain` - will be returned,
+// `eligible_to_join_by_email_domain`, and `eligible_to_join_by_oauth_tenant` - will be returned,
 // and any membership can be assumed by calling the
 // [Exchange Intermediate Session](https://stytch.com/docs/b2b/api/exchange-intermediate-session) endpoint.
 //
@@ -113,12 +115,14 @@ func (c *DiscoveryOrganizationsClient) List(
 	var retVal organizations.ListResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/discovery/organizations",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/discovery/organizations",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/magiclinks.go
+++ b/stytch/b2b/magiclinks.go
@@ -71,12 +71,14 @@ func (c *MagicLinksClient) Authenticate(
 	var retVal magiclinks.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/magic_links/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/magic_links/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -103,11 +105,13 @@ func (c *MagicLinksClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/magic_links/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/magic_links/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/stytch/b2b/magiclinks/types.go
+++ b/stytch/b2b/magiclinks/types.go
@@ -85,10 +85,7 @@ type AuthenticateResponse struct {
 	MemberID string `json:"member_id,omitempty"`
 	// MethodID: The email or device involved in the authentication.
 	MethodID string `json:"method_id,omitempty"`
-	// ResetSessions: Indicates if all Sessions linked to the Member need to be reset. You should check this
-	// field if you aren't using
-	//     Stytch's Session product. If you are using Stytch's Session product, we revoke the Member’s other
-	// Sessions for you.
+	// ResetSessions: This field is deprecated.
 	ResetSessions bool `json:"reset_sessions,omitempty"`
 	// OrganizationID: Globally unique UUID that identifies a specific Organization. The `organization_id` is
 	// critical to perform operations on an Organization, so be sure to preserve this value.

--- a/stytch/b2b/magiclinks_discovery.go
+++ b/stytch/b2b/magiclinks_discovery.go
@@ -46,12 +46,14 @@ func (c *MagicLinksDiscoveryClient) Authenticate(
 	var retVal discovery.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/magic_links/discovery/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/magic_links/discovery/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/magiclinks_email.go
+++ b/stytch/b2b/magiclinks_email.go
@@ -51,12 +51,14 @@ func (c *MagicLinksEmailClient) LoginOrSignup(
 	var retVal email.LoginOrSignupResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/magic_links/email/login_or_signup",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/magic_links/email/login_or_signup",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -88,12 +90,14 @@ func (c *MagicLinksEmailClient) Invite(
 	var retVal email.InviteResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/magic_links/email/invite",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/magic_links/email/invite",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/magiclinks_email_discovery.go
+++ b/stytch/b2b/magiclinks_email_discovery.go
@@ -44,12 +44,14 @@ func (c *MagicLinksEmailDiscoveryClient) Send(
 	var retVal discovery.SendResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/magic_links/email/discovery/send",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/magic_links/email/discovery/send",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/oauth.go
+++ b/stytch/b2b/oauth.go
@@ -76,12 +76,14 @@ func (c *OAuthClient) Authenticate(
 	var retVal oauth.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/oauth/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/oauth/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -108,11 +110,13 @@ func (c *OAuthClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/oauth/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/oauth/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/stytch/b2b/oauth/types.go
+++ b/stytch/b2b/oauth/types.go
@@ -111,8 +111,9 @@ type AuthenticateResponse struct {
 	// critical to perform operations on an Organization, so be sure to preserve this value.
 	OrganizationID string `json:"organization_id,omitempty"`
 	// Organization: The [Organization object](https://stytch.com/docs/b2b/api/organization-object).
-	Organization  organizations.Organization `json:"organization,omitempty"`
-	ResetSessions bool                       `json:"reset_sessions,omitempty"`
+	Organization organizations.Organization `json:"organization,omitempty"`
+	// ResetSessions: This field is deprecated.
+	ResetSessions bool `json:"reset_sessions,omitempty"`
 	// MemberAuthenticated: Indicates whether the Member is fully authenticated. If false, the Member needs to
 	// complete an MFA step to log in to the Organization.
 	MemberAuthenticated bool `json:"member_authenticated,omitempty"`

--- a/stytch/b2b/oauth_discovery.go
+++ b/stytch/b2b/oauth_discovery.go
@@ -46,12 +46,14 @@ func (c *OAuthDiscoveryClient) Authenticate(
 	var retVal discovery.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/oauth/discovery/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/oauth/discovery/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/organizations.go
+++ b/stytch/b2b/organizations.go
@@ -56,12 +56,14 @@ func (c *OrganizationsClient) Create(
 	var retVal organizations.CreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/organizations",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/organizations",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -76,12 +78,14 @@ func (c *OrganizationsClient) Get(
 	var retVal organizations.GetResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/organizations/%s", body.OrganizationID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s", body.OrganizationID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -114,12 +118,14 @@ func (c *OrganizationsClient) Update(
 	var retVal organizations.UpdateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/b2b/organizations/%s", body.OrganizationID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s", body.OrganizationID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -138,12 +144,14 @@ func (c *OrganizationsClient) Delete(
 	var retVal organizations.DeleteResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/b2b/organizations/%s", body.OrganizationID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s", body.OrganizationID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -169,12 +177,14 @@ func (c *OrganizationsClient) Search(
 	var retVal organizations.SearchResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/organizations/search",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/organizations/search",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -188,12 +198,14 @@ func (c *OrganizationsClient) Metrics(
 	var retVal organizations.MetricsResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/organizations/%s/metrics", body.OrganizationID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/metrics", body.OrganizationID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/organizations/types.go
+++ b/stytch/b2b/organizations/types.go
@@ -586,7 +586,8 @@ type Organization struct {
 
 // ResultsMetadata:
 type ResultsMetadata struct {
-	// Total: The total number of results returned by your search query.
+	// Total: The total number of results returned by your search query. If totals have been disabled for your
+	// Stytch Workspace to improve search performance, the value will always be -1.
 	Total int32 `json:"total,omitempty"`
 	// NextCursor: The `next_cursor` string is returned when your search result contains more than one page of
 	// results. This value is passed into your next search call in the `cursor` field.

--- a/stytch/b2b/organizations_members.go
+++ b/stytch/b2b/organizations_members.go
@@ -52,12 +52,14 @@ func (c *OrganizationsMembersClient) Update(
 	var retVal members.UpdateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/%s", body.OrganizationID, body.MemberID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/%s", body.OrganizationID, body.MemberID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -76,12 +78,14 @@ func (c *OrganizationsMembersClient) Delete(
 	var retVal members.DeleteResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/%s", body.OrganizationID, body.MemberID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/%s", body.OrganizationID, body.MemberID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -111,12 +115,14 @@ func (c *OrganizationsMembersClient) Reactivate(
 	var retVal members.ReactivateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/reactivate", body.OrganizationID, body.MemberID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/reactivate", body.OrganizationID, body.MemberID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -144,12 +150,14 @@ func (c *OrganizationsMembersClient) DeleteMFAPhoneNumber(
 	var retVal members.DeleteMFAPhoneNumberResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/mfa_phone_numbers/%s", body.OrganizationID, body.MemberID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/mfa_phone_numbers/%s", body.OrganizationID, body.MemberID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -174,12 +182,14 @@ func (c *OrganizationsMembersClient) DeleteTOTP(
 	var retVal members.DeleteTOTPResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/totp", body.OrganizationID, body.MemberID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/totp", body.OrganizationID, body.MemberID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -210,12 +220,14 @@ func (c *OrganizationsMembersClient) Search(
 	var retVal members.SearchResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/organizations/members/search",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/organizations/members/search",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -234,12 +246,14 @@ func (c *OrganizationsMembersClient) DeletePassword(
 	var retVal members.DeletePasswordResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/passwords/%s", body.OrganizationID, body.MemberPasswordID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/passwords/%s", body.OrganizationID, body.MemberPasswordID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -266,12 +280,14 @@ func (c *OrganizationsMembersClient) DangerouslyGet(
 	var retVal members.GetResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/organizations/members/dangerously_get/%s", body.MemberID),
-		queryParams,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/members/dangerously_get/%s", body.MemberID),
+			QueryParams: queryParams,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -299,12 +315,14 @@ func (c *OrganizationsMembersClient) OIDCProviders(
 	var retVal members.OIDCProvidersResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oidc_providers", body.OrganizationID, body.MemberID),
-		queryParams,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oidc_providers", body.OrganizationID, body.MemberID),
+			QueryParams: queryParams,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -352,12 +370,14 @@ func (c *OrganizationsMembersClient) UnlinkRetiredEmail(
 	var retVal members.UnlinkRetiredEmailResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/unlink_retired_email", body.OrganizationID, body.MemberID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/unlink_retired_email", body.OrganizationID, body.MemberID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -385,12 +405,14 @@ func (c *OrganizationsMembersClient) Create(
 	var retVal members.CreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members", body.OrganizationID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members", body.OrganizationID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -411,12 +433,14 @@ func (c *OrganizationsMembersClient) Get(
 	var retVal members.GetResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/organizations/%s/member", body.OrganizationID),
-		queryParams,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/member", body.OrganizationID),
+			QueryParams: queryParams,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/organizations_members_oauthproviders.go
+++ b/stytch/b2b/organizations_members_oauthproviders.go
@@ -54,12 +54,14 @@ func (c *OrganizationsMembersOAuthProvidersClient) Google(
 	var retVal oauthproviders.GoogleResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oauth_providers/google", body.OrganizationID, body.MemberID),
-		queryParams,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oauth_providers/google", body.OrganizationID, body.MemberID),
+			QueryParams: queryParams,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -87,12 +89,14 @@ func (c *OrganizationsMembersOAuthProvidersClient) Microsoft(
 	var retVal oauthproviders.MicrosoftResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oauth_providers/microsoft", body.OrganizationID, body.MemberID),
-		queryParams,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oauth_providers/microsoft", body.OrganizationID, body.MemberID),
+			QueryParams: queryParams,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -109,12 +113,14 @@ func (c *OrganizationsMembersOAuthProvidersClient) Slack(
 	var retVal oauthproviders.SlackResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oauth_providers/slack", body.OrganizationID, body.MemberID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oauth_providers/slack", body.OrganizationID, body.MemberID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -142,12 +148,14 @@ func (c *OrganizationsMembersOAuthProvidersClient) Hubspot(
 	var retVal oauthproviders.HubspotResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oauth_providers/hubspot", body.OrganizationID, body.MemberID),
-		queryParams,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oauth_providers/hubspot", body.OrganizationID, body.MemberID),
+			QueryParams: queryParams,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -175,12 +183,14 @@ func (c *OrganizationsMembersOAuthProvidersClient) Github(
 	var retVal oauthproviders.GithubResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oauth_providers/github", body.OrganizationID, body.MemberID),
-		queryParams,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/organizations/%s/members/%s/oauth_providers/github", body.OrganizationID, body.MemberID),
+			QueryParams: queryParams,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/otp_email.go
+++ b/stytch/b2b/otp_email.go
@@ -54,12 +54,14 @@ func (c *OTPsEmailClient) LoginOrSignup(
 	var retVal email.LoginOrSignupResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/otps/email/login_or_signup",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/otps/email/login_or_signup",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -105,12 +107,14 @@ func (c *OTPsEmailClient) Authenticate(
 	var retVal email.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/otps/email/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/otps/email/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -137,11 +141,13 @@ func (c *OTPsEmailClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/otps/email/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/otps/email/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/stytch/b2b/otp_email_discovery.go
+++ b/stytch/b2b/otp_email_discovery.go
@@ -46,12 +46,14 @@ func (c *OTPsEmailDiscoveryClient) Send(
 	var retVal discovery.SendResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/otps/email/discovery/send",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/otps/email/discovery/send",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -76,12 +78,14 @@ func (c *OTPsEmailDiscoveryClient) Authenticate(
 	var retVal discovery.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/otps/email/discovery/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/otps/email/discovery/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/otp_sms.go
+++ b/stytch/b2b/otp_sms.go
@@ -79,12 +79,14 @@ func (c *OTPsSmsClient) Send(
 	var retVal sms.SendResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/otps/sms/send",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/otps/sms/send",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -136,12 +138,14 @@ func (c *OTPsSmsClient) Authenticate(
 	var retVal sms.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/otps/sms/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/otps/sms/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -168,11 +172,13 @@ func (c *OTPsSmsClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/otps/sms/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/otps/sms/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/stytch/b2b/passwords.go
+++ b/stytch/b2b/passwords.go
@@ -76,12 +76,14 @@ func (c *PasswordsClient) StrengthCheck(
 	var retVal passwords.StrengthCheckResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/strength_check",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/strength_check",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -109,12 +111,14 @@ func (c *PasswordsClient) Migrate(
 	var retVal passwords.MigrateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/migrate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/migrate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -156,12 +160,14 @@ func (c *PasswordsClient) Authenticate(
 	var retVal passwords.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -188,11 +194,13 @@ func (c *PasswordsClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/stytch/b2b/passwords/discovery/email/types.go
+++ b/stytch/b2b/passwords/discovery/email/types.go
@@ -71,9 +71,26 @@ type ResetResponse struct {
 	// [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an
 	// MFA flow and log in to the Organization. Password factors are not transferable between Organizations, so
 	// the intermediate session token is not valid for use with discovery endpoints.
-	IntermediateSessionToken string                             `json:"intermediate_session_token,omitempty"`
-	EmailAddress             string                             `json:"email_address,omitempty"`
-	DiscoveredOrganizations  []discovery.DiscoveredOrganization `json:"discovered_organizations,omitempty"`
+	IntermediateSessionToken string `json:"intermediate_session_token,omitempty"`
+	// EmailAddress: The email address.
+	EmailAddress string `json:"email_address,omitempty"`
+	// DiscoveredOrganizations: An array of `discovered_organization` objects tied to the
+	// `intermediate_session_token`, `session_token`, or `session_jwt`. See the
+	// [Discovered Organization Object](https://stytch.com/docs/b2b/api/discovered-organization-object) for
+	// complete details.
+	//
+	//   Note that Organizations will only appear here under any of the following conditions:
+	//   1. The end user is already a Member of the Organization.
+	//   2. The end user is invited to the Organization.
+	//   3. The end user can join the Organization because:
+	//
+	//       a) The Organization allows JIT provisioning.
+	//
+	//       b) The Organizations' allowed domains list contains the Member's email domain.
+	//
+	//       c) The Organization has at least one other Member with a verified email address with the same
+	// domain as the end user (to prevent phishing attacks).
+	DiscoveredOrganizations []discovery.DiscoveredOrganization `json:"discovered_organizations,omitempty"`
 	// StatusCode: The HTTP status code of the response. Stytch follows standard HTTP response status code
 	// patterns, e.g. 2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX
 	// are server errors.

--- a/stytch/b2b/passwords_discovery.go
+++ b/stytch/b2b/passwords_discovery.go
@@ -58,12 +58,14 @@ func (c *PasswordsDiscoveryClient) Authenticate(
 	var retVal discovery.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/discovery/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/discovery/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/passwords_discovery_email.go
+++ b/stytch/b2b/passwords_discovery_email.go
@@ -55,12 +55,14 @@ func (c *PasswordsDiscoveryEmailClient) ResetStart(
 	var retVal email.ResetStartResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/discovery/email/reset/start",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/discovery/email/reset/start",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -92,12 +94,14 @@ func (c *PasswordsDiscoveryEmailClient) Reset(
 	var retVal email.ResetResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/discovery/email/reset",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/discovery/email/reset",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/passwords_email.go
+++ b/stytch/b2b/passwords_email.go
@@ -54,12 +54,14 @@ func (c *PasswordsEmailClient) ResetStart(
 	var retVal email.ResetStartResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/email/reset/start",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/email/reset/start",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -100,12 +102,14 @@ func (c *PasswordsEmailClient) Reset(
 	var retVal email.ResetResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/email/reset",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/email/reset",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -134,12 +138,14 @@ func (c *PasswordsEmailClient) RequireReset(
 	var retVal email.RequireResetResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/email/require_reset",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/email/require_reset",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/passwords_existingpassword.go
+++ b/stytch/b2b/passwords_existingpassword.go
@@ -66,12 +66,14 @@ func (c *PasswordsExistingPasswordClient) Reset(
 	var retVal existingpassword.ResetResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/existing_password/reset",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/existing_password/reset",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/passwords_session.go
+++ b/stytch/b2b/passwords_session.go
@@ -49,12 +49,14 @@ func (c *PasswordsSessionsClient) Reset(
 	var retVal session.ResetResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/passwords/session/reset",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/passwords/session/reset",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/rbac.go
+++ b/stytch/b2b/rbac.go
@@ -46,12 +46,14 @@ func (c *RBACClient) Policy(
 	var retVal rbac.PolicyResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		"/v1/b2b/rbac/policy",
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        "/v1/b2b/rbac/policy",
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/recoverycodes.go
+++ b/stytch/b2b/recoverycodes.go
@@ -46,12 +46,14 @@ func (c *RecoveryCodesClient) Recover(
 	var retVal recoverycodes.RecoverResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/recovery_codes/recover",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/recovery_codes/recover",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -66,12 +68,14 @@ func (c *RecoveryCodesClient) Get(
 	var retVal recoverycodes.GetResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/recovery_codes/%s/%s", body.OrganizationID, body.MemberID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/recovery_codes/%s/%s", body.OrganizationID, body.MemberID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -96,12 +100,14 @@ func (c *RecoveryCodesClient) Rotate(
 	var retVal recoverycodes.RotateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/recovery_codes/rotate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/recovery_codes/rotate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/scim/connection/types.go
+++ b/stytch/b2b/scim/connection/types.go
@@ -252,7 +252,9 @@ type GetResponse struct {
 	// StatusCode: The HTTP status code of the response. Stytch follows standard HTTP response status code
 	// patterns, e.g. 2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX
 	// are server errors.
-	StatusCode int32                `json:"status_code,omitempty"`
+	StatusCode int32 `json:"status_code,omitempty"`
+	// Connection: A [SCIM Connection](https://stytch.com/docs/b2b/api/scim-connection-object) connection
+	// belonging to the organization (currently limited to one).
 	Connection *scim.SCIMConnection `json:"connection,omitempty"`
 }
 

--- a/stytch/b2b/scim_connection.go
+++ b/stytch/b2b/scim_connection.go
@@ -50,12 +50,14 @@ func (c *SCIMConnectionClient) Update(
 	var retVal connection.UpdateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/b2b/scim/%s/connection/%s", body.OrganizationID, body.ConnectionID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/b2b/scim/%s/connection/%s", body.OrganizationID, body.ConnectionID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -74,12 +76,14 @@ func (c *SCIMConnectionClient) Delete(
 	var retVal connection.DeleteResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/b2b/scim/%s/connection/%s", body.OrganizationID, body.ConnectionID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/b2b/scim/%s/connection/%s", body.OrganizationID, body.ConnectionID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -107,12 +111,14 @@ func (c *SCIMConnectionClient) RotateStart(
 	var retVal connection.RotateStartResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/b2b/scim/%s/connection/%s/rotate/start", body.OrganizationID, body.ConnectionID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/b2b/scim/%s/connection/%s/rotate/start", body.OrganizationID, body.ConnectionID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -142,12 +148,14 @@ func (c *SCIMConnectionClient) RotateComplete(
 	var retVal connection.RotateCompleteResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/b2b/scim/%s/connection/%s/rotate/complete", body.OrganizationID, body.ConnectionID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/b2b/scim/%s/connection/%s/rotate/complete", body.OrganizationID, body.ConnectionID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -176,12 +184,14 @@ func (c *SCIMConnectionClient) RotateCancel(
 	var retVal connection.RotateCancelResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/b2b/scim/%s/connection/%s/rotate/cancel", body.OrganizationID, body.ConnectionID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/b2b/scim/%s/connection/%s/rotate/cancel", body.OrganizationID, body.ConnectionID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -206,12 +216,14 @@ func (c *SCIMConnectionClient) GetGroups(
 	var retVal connection.GetGroupsResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/scim/%s/connection/%s", body.OrganizationID, body.ConnectionID),
-		queryParams,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/scim/%s/connection/%s", body.OrganizationID, body.ConnectionID),
+			QueryParams: queryParams,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -239,12 +251,14 @@ func (c *SCIMConnectionClient) Create(
 	var retVal connection.CreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/b2b/scim/%s/connection", body.OrganizationID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/b2b/scim/%s/connection", body.OrganizationID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -263,12 +277,14 @@ func (c *SCIMConnectionClient) Get(
 	var retVal connection.GetResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/scim/%s/connection", body.OrganizationID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/scim/%s/connection", body.OrganizationID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/sessions.go
+++ b/stytch/b2b/sessions.go
@@ -52,12 +52,14 @@ func (c *SessionsClient) Get(
 	var retVal sessions.GetResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		"/v1/b2b/sessions",
-		queryParams,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        "/v1/b2b/sessions",
+			QueryParams: queryParams,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -101,12 +103,14 @@ func (c *SessionsClient) Authenticate(
 	var retVal sessions.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/sessions/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/sessions/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -133,11 +137,13 @@ func (c *SessionsClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/sessions/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/sessions/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -200,12 +206,14 @@ func (c *SessionsClient) Revoke(
 	var retVal sessions.RevokeResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/sessions/revoke",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/sessions/revoke",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -253,12 +261,14 @@ func (c *SessionsClient) Exchange(
 	var retVal sessions.ExchangeResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/sessions/exchange",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/sessions/exchange",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -286,12 +296,14 @@ func (c *SessionsClient) Migrate(
 	var retVal sessions.MigrateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/sessions/migrate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/sessions/migrate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -324,12 +336,14 @@ func (c *SessionsClient) GetJWKS(
 	var retVal sessions.GetJWKSResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/sessions/jwks/%s", body.ProjectID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/sessions/jwks/%s", body.ProjectID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/sso.go
+++ b/stytch/b2b/sso.go
@@ -48,12 +48,14 @@ func (c *SSOClient) GetConnections(
 	var retVal sso.GetConnectionsResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/b2b/sso/%s", body.OrganizationID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/b2b/sso/%s", body.OrganizationID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -72,12 +74,14 @@ func (c *SSOClient) DeleteConnection(
 	var retVal sso.DeleteConnectionResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/b2b/sso/%s/connections/%s", body.OrganizationID, body.ConnectionID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/b2b/sso/%s/connections/%s", body.OrganizationID, body.ConnectionID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -120,12 +124,14 @@ func (c *SSOClient) Authenticate(
 	var retVal sso.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/sso/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/sso/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -152,11 +158,13 @@ func (c *SSOClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/sso/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/sso/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/stytch/b2b/sso/types.go
+++ b/stytch/b2b/sso/types.go
@@ -255,10 +255,7 @@ type AuthenticateResponse struct {
 	SessionToken string `json:"session_token,omitempty"`
 	// SessionJWT: The JSON Web Token (JWT) for a given Stytch Session.
 	SessionJWT string `json:"session_jwt,omitempty"`
-	// ResetSession: Indicates if all Sessions linked to the Member need to be reset. You should check this
-	// field if you aren't using
-	//     Stytch's Session product. If you are using Stytch's Session product, we revoke the Member’s other
-	// Sessions for you.
+	// ResetSession: This field is deprecated.
 	ResetSession bool `json:"reset_session,omitempty"`
 	// Organization: The [Organization object](https://stytch.com/docs/b2b/api/organization-object).
 	Organization organizations.Organization `json:"organization,omitempty"`

--- a/stytch/b2b/sso_external.go
+++ b/stytch/b2b/sso_external.go
@@ -49,12 +49,14 @@ func (c *SSOExternalClient) CreateConnection(
 	var retVal external.CreateConnectionResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/b2b/sso/external/%s", body.OrganizationID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/b2b/sso/external/%s", body.OrganizationID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -82,12 +84,14 @@ func (c *SSOExternalClient) UpdateConnection(
 	var retVal external.UpdateConnectionResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/b2b/sso/external/%s/connections/%s", body.OrganizationID, body.ConnectionID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/b2b/sso/external/%s/connections/%s", body.OrganizationID, body.ConnectionID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/sso_oidc.go
+++ b/stytch/b2b/sso_oidc.go
@@ -49,12 +49,14 @@ func (c *SSOOIDCClient) CreateConnection(
 	var retVal oidc.CreateConnectionResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/b2b/sso/oidc/%s", body.OrganizationID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/b2b/sso/oidc/%s", body.OrganizationID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -107,12 +109,14 @@ func (c *SSOOIDCClient) UpdateConnection(
 	var retVal oidc.UpdateConnectionResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/b2b/sso/oidc/%s/connections/%s", body.OrganizationID, body.ConnectionID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/b2b/sso/oidc/%s/connections/%s", body.OrganizationID, body.ConnectionID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/sso_saml.go
+++ b/stytch/b2b/sso_saml.go
@@ -49,12 +49,14 @@ func (c *SSOSAMLClient) CreateConnection(
 	var retVal saml.CreateConnectionResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/b2b/sso/saml/%s", body.OrganizationID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/b2b/sso/saml/%s", body.OrganizationID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -88,12 +90,14 @@ func (c *SSOSAMLClient) UpdateConnection(
 	var retVal saml.UpdateConnectionResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/b2b/sso/saml/%s/connections/%s", body.OrganizationID, body.ConnectionID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/b2b/sso/saml/%s/connections/%s", body.OrganizationID, body.ConnectionID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -127,12 +131,14 @@ func (c *SSOSAMLClient) UpdateByURL(
 	var retVal saml.UpdateByURLResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/b2b/sso/saml/%s/connections/%s/url", body.OrganizationID, body.ConnectionID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/b2b/sso/saml/%s/connections/%s/url", body.OrganizationID, body.ConnectionID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -154,12 +160,14 @@ func (c *SSOSAMLClient) DeleteVerificationCertificate(
 	var retVal saml.DeleteVerificationCertificateResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/b2b/sso/saml/%s/connections/%s/verification_certificates/%s", body.OrganizationID, body.ConnectionID, body.CertificateID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/b2b/sso/saml/%s/connections/%s/verification_certificates/%s", body.OrganizationID, body.ConnectionID, body.CertificateID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/b2b/totps.go
+++ b/stytch/b2b/totps.go
@@ -50,12 +50,14 @@ func (c *TOTPsClient) Create(
 	var retVal totps.CreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/totp",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/totp",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -79,12 +81,14 @@ func (c *TOTPsClient) Authenticate(
 	var retVal totps.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/totp/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/totp/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -111,11 +115,13 @@ func (c *TOTPsClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/totp/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/totp/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -173,12 +179,14 @@ func (c *TOTPsClient) Migrate(
 	var retVal totps.MigrateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/b2b/totp/migrate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/b2b/totp/migrate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "15.10.0"
+const APIVersion = "15.11.0"

--- a/stytch/consumer/cryptowallets.go
+++ b/stytch/consumer/cryptowallets.go
@@ -54,12 +54,14 @@ func (c *CryptoWalletsClient) AuthenticateStart(
 	var retVal cryptowallets.AuthenticateStartResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/crypto_wallets/authenticate/start",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/crypto_wallets/authenticate/start",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -83,12 +85,14 @@ func (c *CryptoWalletsClient) Authenticate(
 	var retVal cryptowallets.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/crypto_wallets/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/crypto_wallets/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -115,11 +119,13 @@ func (c *CryptoWalletsClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/crypto_wallets/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/crypto_wallets/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/stytch/consumer/m2m/types.go
+++ b/stytch/consumer/m2m/types.go
@@ -98,7 +98,8 @@ type M2MSearchQuery struct {
 
 // ResultsMetadata:
 type ResultsMetadata struct {
-	// Total: The total number of results returned by your search query.
+	// Total: The total number of results returned by your search query. If totals have been disabled for your
+	// Stytch Workspace to improve search performance, the value will always be -1.
 	Total int32 `json:"total,omitempty"`
 	// NextCursor: The `next_cursor` string is returned when your search result contains more than one page of
 	// results. This value is passed into your next search call in the `cursor` field.

--- a/stytch/consumer/m2m_clients.go
+++ b/stytch/consumer/m2m_clients.go
@@ -39,12 +39,14 @@ func (c *M2MClientsClient) Get(
 	var retVal clients.GetResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/m2m/clients/%s", body.ClientID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/m2m/clients/%s", body.ClientID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -74,12 +76,14 @@ func (c *M2MClientsClient) Search(
 	var retVal clients.SearchResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/m2m/clients/search",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/m2m/clients/search",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -110,12 +114,14 @@ func (c *M2MClientsClient) Update(
 	var retVal clients.UpdateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/m2m/clients/%s", body.ClientID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/m2m/clients/%s", body.ClientID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -135,12 +141,14 @@ func (c *M2MClientsClient) Delete(
 	var retVal clients.DeleteResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/m2m/clients/%s", body.ClientID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/m2m/clients/%s", body.ClientID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -172,12 +180,14 @@ func (c *M2MClientsClient) Create(
 	var retVal clients.CreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/m2m/clients",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/m2m/clients",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/m2m_clients_secrets.go
+++ b/stytch/consumer/m2m_clients_secrets.go
@@ -55,12 +55,14 @@ func (c *M2MClientsSecretsClient) RotateStart(
 	var retVal secrets.RotateStartResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/m2m/clients/%s/secrets/rotate/start", body.ClientID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/m2m/clients/%s/secrets/rotate/start", body.ClientID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -88,12 +90,14 @@ func (c *M2MClientsSecretsClient) RotateCancel(
 	var retVal secrets.RotateCancelResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/m2m/clients/%s/secrets/rotate/cancel", body.ClientID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/m2m/clients/%s/secrets/rotate/cancel", body.ClientID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -121,12 +125,14 @@ func (c *M2MClientsSecretsClient) Rotate(
 	var retVal secrets.RotateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		fmt.Sprintf("/v1/m2m/clients/%s/secrets/rotate", body.ClientID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        fmt.Sprintf("/v1/m2m/clients/%s/secrets/rotate", body.ClientID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/magiclinks.go
+++ b/stytch/consumer/magiclinks.go
@@ -51,12 +51,14 @@ func (c *MagicLinksClient) Authenticate(
 	var retVal magiclinks.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/magic_links/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/magic_links/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -83,11 +85,13 @@ func (c *MagicLinksClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/magic_links/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/magic_links/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -151,12 +155,14 @@ func (c *MagicLinksClient) Create(
 	var retVal magiclinks.CreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/magic_links",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/magic_links",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/magiclinks/types.go
+++ b/stytch/consumer/magiclinks/types.go
@@ -20,7 +20,7 @@ type AuthenticateParams struct {
 	// `https://example.com/authenticate?stytch_token_type=magic_links&token=rM_kw42CWBhsHLF62V75jELMbvJ87njMe3tFVj7Qupu7`
 	//
 	//       In the redirect URL, the `stytch_token_type` will be `magic_link`. See
-	// [here](https://stytch.com/docs/guides/dashboard/redirect-urls) for more detail.
+	// [here](/workspace-management/redirect-urls) for more detail.
 	Token string `json:"token,omitempty"`
 	// Attributes: Provided attributes help with fraud detection.
 	Attributes *attribute.Attributes `json:"attributes,omitempty"`

--- a/stytch/consumer/magiclinks_email.go
+++ b/stytch/consumer/magiclinks_email.go
@@ -61,12 +61,14 @@ func (c *MagicLinksEmailClient) Send(
 	var retVal email.SendResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/magic_links/email/send",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/magic_links/email/send",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -100,12 +102,14 @@ func (c *MagicLinksEmailClient) LoginOrCreate(
 	var retVal email.LoginOrCreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/magic_links/email/login_or_create",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/magic_links/email/login_or_create",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -137,12 +141,14 @@ func (c *MagicLinksEmailClient) Invite(
 	var retVal email.InviteResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/magic_links/email/invite",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/magic_links/email/invite",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -166,12 +172,14 @@ func (c *MagicLinksEmailClient) RevokeInvite(
 	var retVal email.RevokeInviteResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/magic_links/email/revoke_invite",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/magic_links/email/revoke_invite",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/oauth.go
+++ b/stytch/consumer/oauth.go
@@ -55,12 +55,14 @@ func (c *OAuthClient) Attach(
 	var retVal oauth.AttachResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/oauth/attach",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/oauth/attach",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -87,12 +89,14 @@ func (c *OAuthClient) Authenticate(
 	var retVal oauth.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/oauth/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/oauth/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -119,11 +123,13 @@ func (c *OAuthClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/oauth/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/oauth/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/stytch/consumer/oauth/types.go
+++ b/stytch/consumer/oauth/types.go
@@ -33,7 +33,7 @@ type AuthenticateParams struct {
 	// `https://example.com/authenticate?stytch_token_type=oauth&token=rM_kw42CWBhsHLF62V75jELMbvJ87njMe3tFVj7Qupu7`
 	//
 	//       In the redirect URL, the `stytch_token_type` will be `oauth`. See
-	// [here](https://stytch.com/docs/guides/dashboard/redirect-urls) for more detail.
+	// [here](/workspace-management/redirect-urls) for more detail.
 	Token string `json:"token,omitempty"`
 	// SessionToken: Reuse an existing session instead of creating a new one. If you provide us with a
 	// `session_token`, then we'll update the session represented by this session token with this OAuth factor.

--- a/stytch/consumer/otp.go
+++ b/stytch/consumer/otp.go
@@ -57,12 +57,14 @@ func (c *OTPsClient) Authenticate(
 	var retVal otp.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/otps/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/otps/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -89,11 +91,13 @@ func (c *OTPsClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/otps/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/otps/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/stytch/consumer/otp_email.go
+++ b/stytch/consumer/otp_email.go
@@ -59,12 +59,14 @@ func (c *OTPsEmailClient) Send(
 	var retVal email.SendResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/otps/email/send",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/otps/email/send",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -95,12 +97,14 @@ func (c *OTPsEmailClient) LoginOrCreate(
 	var retVal email.LoginOrCreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/otps/email/login_or_create",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/otps/email/login_or_create",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/otp_sms.go
+++ b/stytch/consumer/otp_sms.go
@@ -75,12 +75,14 @@ func (c *OTPsSmsClient) Send(
 	var retVal sms.SendResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/otps/sms/send",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/otps/sms/send",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -123,12 +125,14 @@ func (c *OTPsSmsClient) LoginOrCreate(
 	var retVal sms.LoginOrCreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/otps/sms/login_or_create",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/otps/sms/login_or_create",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/otp_whatsapp.go
+++ b/stytch/consumer/otp_whatsapp.go
@@ -68,12 +68,14 @@ func (c *OTPsWhatsappClient) Send(
 	var retVal whatsapp.SendResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/otps/whatsapp/send",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/otps/whatsapp/send",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -109,12 +111,14 @@ func (c *OTPsWhatsappClient) LoginOrCreate(
 	var retVal whatsapp.LoginOrCreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/otps/whatsapp/login_or_create",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/otps/whatsapp/login_or_create",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/passwords.go
+++ b/stytch/consumer/passwords.go
@@ -68,12 +68,14 @@ func (c *PasswordsClient) Create(
 	var retVal passwords.CreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/passwords",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/passwords",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -115,12 +117,14 @@ func (c *PasswordsClient) Authenticate(
 	var retVal passwords.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/passwords/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/passwords/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -147,11 +151,13 @@ func (c *PasswordsClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/passwords/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/passwords/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -229,12 +235,14 @@ func (c *PasswordsClient) StrengthCheck(
 	var retVal passwords.StrengthCheckResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/passwords/strength_check",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/passwords/strength_check",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -260,12 +268,14 @@ func (c *PasswordsClient) Migrate(
 	var retVal passwords.MigrateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/passwords/migrate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/passwords/migrate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/passwords/email/types.go
+++ b/stytch/consumer/passwords/email/types.go
@@ -19,8 +19,7 @@ type ResetParams struct {
 	//
 	//       In the redirect URL, the `stytch_token_type` will be `login` or `reset_password`.
 	//
-	//       See examples and read more about redirect URLs
-	// [here](https://stytch.com/docs/guides/dashboard/redirect-urls).
+	//       See examples and read more about redirect URLs [here](/workspace-management/redirect-urls).
 	Token string `json:"token,omitempty"`
 	// Password: The password for the user. Any UTF8 character is allowed, e.g. spaces, emojis, non-English
 	// characers, etc.

--- a/stytch/consumer/passwords_email.go
+++ b/stytch/consumer/passwords_email.go
@@ -45,12 +45,14 @@ func (c *PasswordsEmailClient) ResetStart(
 	var retVal email.ResetStartResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/passwords/email/reset/start",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/passwords/email/reset/start",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -82,12 +84,14 @@ func (c *PasswordsEmailClient) Reset(
 	var retVal email.ResetResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/passwords/email/reset",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/passwords/email/reset",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/passwords_existingpassword.go
+++ b/stytch/consumer/passwords_existingpassword.go
@@ -47,12 +47,14 @@ func (c *PasswordsExistingPasswordClient) Reset(
 	var retVal existingpassword.ResetResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/passwords/existing_password/reset",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/passwords/existing_password/reset",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/passwords_session.go
+++ b/stytch/consumer/passwords_session.go
@@ -50,12 +50,14 @@ func (c *PasswordsSessionsClient) Reset(
 	var retVal session.ResetResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/passwords/session/reset",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/passwords/session/reset",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/project.go
+++ b/stytch/consumer/project.go
@@ -32,12 +32,14 @@ func (c *ProjectClient) Metrics(
 	var retVal project.MetricsResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		"/v1/projects/metrics",
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        "/v1/projects/metrics",
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -49,12 +49,14 @@ func (c *SessionsClient) Get(
 	var retVal sessions.GetResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		"/v1/sessions",
-		queryParams,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        "/v1/sessions",
+			QueryParams: queryParams,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -87,12 +89,14 @@ func (c *SessionsClient) Authenticate(
 	var retVal sessions.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/sessions/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/sessions/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -119,11 +123,13 @@ func (c *SessionsClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/sessions/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/sessions/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -182,12 +188,14 @@ func (c *SessionsClient) Revoke(
 	var retVal sessions.RevokeResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/sessions/revoke",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/sessions/revoke",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -215,12 +223,14 @@ func (c *SessionsClient) Migrate(
 	var retVal sessions.MigrateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/sessions/migrate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/sessions/migrate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -252,12 +262,14 @@ func (c *SessionsClient) GetJWKS(
 	var retVal sessions.GetJWKSResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/sessions/jwks/%s", body.ProjectID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/sessions/jwks/%s", body.ProjectID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/sessions/types.go
+++ b/stytch/consumer/sessions/types.go
@@ -118,6 +118,8 @@ type AuthenticationFactor struct {
 	SlackOAuthExchangeFactor   *SlackOAuthExchangeFactor   `json:"slack_oauth_exchange_factor,omitempty"`
 	HubspotOAuthExchangeFactor *HubspotOAuthExchangeFactor `json:"hubspot_oauth_exchange_factor,omitempty"`
 	GithubOAuthExchangeFactor  *GithubOAuthExchangeFactor  `json:"github_oauth_exchange_factor,omitempty"`
+	GoogleOAuthExchangeFactor  *GoogleOAuthExchangeFactor  `json:"google_oauth_exchange_factor,omitempty"`
+	ImpersonatedFactor         *ImpersonatedFactor         `json:"impersonated_factor,omitempty"`
 }
 
 // AuthenticatorAppFactor:
@@ -206,6 +208,10 @@ type GithubOAuthFactor struct {
 	EmailID         string `json:"email_id,omitempty"`
 }
 
+type GoogleOAuthExchangeFactor struct {
+	EmailID string `json:"email_id,omitempty"`
+}
+
 // GoogleOAuthFactor:
 type GoogleOAuthFactor struct {
 	// ID: The unique ID of an OAuth registration.
@@ -225,6 +231,11 @@ type HubspotOAuthFactor struct {
 	ID              string `json:"id,omitempty"`
 	ProviderSubject string `json:"provider_subject,omitempty"`
 	EmailID         string `json:"email_id,omitempty"`
+}
+
+type ImpersonatedFactor struct {
+	ImpersonatorID           string `json:"impersonator_id,omitempty"`
+	ImpersonatorEmailAddress string `json:"impersonator_email_address,omitempty"`
 }
 
 type InstagramOAuthFactor struct {
@@ -557,6 +568,8 @@ const (
 	AuthenticationFactorDeliveryMethodOAuthExchangeSlack   AuthenticationFactorDeliveryMethod = "oauth_exchange_slack"
 	AuthenticationFactorDeliveryMethodOAuthExchangeHubspot AuthenticationFactorDeliveryMethod = "oauth_exchange_hubspot"
 	AuthenticationFactorDeliveryMethodOAuthExchangeGithub  AuthenticationFactorDeliveryMethod = "oauth_exchange_github"
+	AuthenticationFactorDeliveryMethodOAuthExchangeGoogle  AuthenticationFactorDeliveryMethod = "oauth_exchange_google"
+	AuthenticationFactorDeliveryMethodImpersonation        AuthenticationFactorDeliveryMethod = "impersonation"
 )
 
 type AuthenticationFactorType string
@@ -574,6 +587,7 @@ const (
 	AuthenticationFactorTypeImported           AuthenticationFactorType = "imported"
 	AuthenticationFactorTypeRecoveryCodes      AuthenticationFactorType = "recovery_codes"
 	AuthenticationFactorTypeEmailOTP           AuthenticationFactorType = "email_otp"
+	AuthenticationFactorTypeImpersonated       AuthenticationFactorType = "impersonated"
 )
 
 // MANUAL(Types)(TYPES)

--- a/stytch/consumer/totps.go
+++ b/stytch/consumer/totps.go
@@ -47,12 +47,14 @@ func (c *TOTPsClient) Create(
 	var retVal totps.CreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/totps",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/totps",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -76,12 +78,14 @@ func (c *TOTPsClient) Authenticate(
 	var retVal totps.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/totps/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/totps/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -108,11 +112,13 @@ func (c *TOTPsClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/totps/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/totps/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -169,12 +175,14 @@ func (c *TOTPsClient) RecoveryCodes(
 	var retVal totps.RecoveryCodesResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/totps/recovery_codes",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/totps/recovery_codes",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -198,12 +206,14 @@ func (c *TOTPsClient) Recover(
 	var retVal totps.RecoverResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/totps/recover",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/totps/recover",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/users.go
+++ b/stytch/consumer/users.go
@@ -46,12 +46,14 @@ func (c *UsersClient) Create(
 	var retVal users.CreateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/users",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/users",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -66,12 +68,14 @@ func (c *UsersClient) Get(
 	var retVal users.GetResponse
 	err := c.C.NewRequest(
 		ctx,
-		"GET",
-		fmt.Sprintf("/v1/users/%s", body.UserID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "GET",
+			Path:        fmt.Sprintf("/v1/users/%s", body.UserID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -105,12 +109,14 @@ func (c *UsersClient) Search(
 	var retVal users.SearchResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/users/search",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/users/search",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -143,12 +149,14 @@ func (c *UsersClient) Update(
 	var retVal users.UpdateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/users/%s", body.UserID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/users/%s", body.UserID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -179,12 +187,14 @@ func (c *UsersClient) ExchangePrimaryFactor(
 	var retVal users.ExchangePrimaryFactorResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/users/%s/exchange_primary_factor", body.UserID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/users/%s/exchange_primary_factor", body.UserID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -199,12 +209,14 @@ func (c *UsersClient) Delete(
 	var retVal users.DeleteResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/users/%s", body.UserID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/users/%s", body.UserID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -219,12 +231,14 @@ func (c *UsersClient) DeleteEmail(
 	var retVal users.DeleteEmailResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/users/emails/%s", body.EmailID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/users/emails/%s", body.EmailID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -239,12 +253,14 @@ func (c *UsersClient) DeletePhoneNumber(
 	var retVal users.DeletePhoneNumberResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/users/phone_numbers/%s", body.PhoneID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/users/phone_numbers/%s", body.PhoneID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -259,12 +275,14 @@ func (c *UsersClient) DeleteWebAuthnRegistration(
 	var retVal users.DeleteWebAuthnRegistrationResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/users/webauthn_registrations/%s", body.WebAuthnRegistrationID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/users/webauthn_registrations/%s", body.WebAuthnRegistrationID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -279,12 +297,14 @@ func (c *UsersClient) DeleteBiometricRegistration(
 	var retVal users.DeleteBiometricRegistrationResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/users/biometric_registrations/%s", body.BiometricRegistrationID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/users/biometric_registrations/%s", body.BiometricRegistrationID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -299,12 +319,14 @@ func (c *UsersClient) DeleteTOTP(
 	var retVal users.DeleteTOTPResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/users/totps/%s", body.TOTPID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/users/totps/%s", body.TOTPID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -319,12 +341,14 @@ func (c *UsersClient) DeleteCryptoWallet(
 	var retVal users.DeleteCryptoWalletResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/users/crypto_wallets/%s", body.CryptoWalletID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/users/crypto_wallets/%s", body.CryptoWalletID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -339,12 +363,14 @@ func (c *UsersClient) DeletePassword(
 	var retVal users.DeletePasswordResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/users/passwords/%s", body.PasswordID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/users/passwords/%s", body.PasswordID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -359,12 +385,14 @@ func (c *UsersClient) DeleteOAuthRegistration(
 	var retVal users.DeleteOAuthRegistrationResponse
 	err := c.C.NewRequest(
 		ctx,
-		"DELETE",
-		fmt.Sprintf("/v1/users/oauth/%s", body.OAuthUserRegistrationID),
-		nil,
-		nil,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "DELETE",
+			Path:        fmt.Sprintf("/v1/users/oauth/%s", body.OAuthUserRegistrationID),
+			QueryParams: nil,
+			Body:        nil,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }

--- a/stytch/consumer/users/types.go
+++ b/stytch/consumer/users/types.go
@@ -196,7 +196,8 @@ type PhoneNumber struct {
 
 // ResultsMetadata:
 type ResultsMetadata struct {
-	// Total: The total number of results returned by your search query.
+	// Total: The total number of results returned by your search query. If totals have been disabled for your
+	// Stytch Workspace to improve search performance, the value will always be -1.
 	Total int32 `json:"total,omitempty"`
 	// NextCursor: The `next_cursor` string is returned when your search result contains more than one page of
 	// results. This value is passed into your next search call in the `cursor` field.

--- a/stytch/consumer/webauthn.go
+++ b/stytch/consumer/webauthn.go
@@ -61,12 +61,14 @@ func (c *WebAuthnClient) RegisterStart(
 	var retVal webauthn.RegisterStartResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/webauthn/register/start",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/webauthn/register/start",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -99,12 +101,14 @@ func (c *WebAuthnClient) Register(
 	var retVal webauthn.RegisterResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/webauthn/register",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/webauthn/register",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -140,12 +144,14 @@ func (c *WebAuthnClient) AuthenticateStart(
 	var retVal webauthn.AuthenticateStartResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/webauthn/authenticate/start",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/webauthn/authenticate/start",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -177,12 +183,14 @@ func (c *WebAuthnClient) Authenticate(
 	var retVal webauthn.AuthenticateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"POST",
-		"/v1/webauthn/authenticate",
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/webauthn/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }
@@ -209,11 +217,13 @@ func (c *WebAuthnClient) AuthenticateWithClaims(
 
 	b, err := c.C.RawRequest(
 		ctx,
-		"POST",
-		"/v1/webauthn/authenticate",
-		nil,
-		jsonBody,
-		headers,
+		stytch.RequestParams{
+			Method:      "POST",
+			Path:        "/v1/webauthn/authenticate",
+			QueryParams: nil,
+			Body:        jsonBody,
+			Headers:     headers,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -270,12 +280,14 @@ func (c *WebAuthnClient) Update(
 	var retVal webauthn.UpdateResponse
 	err = c.C.NewRequest(
 		ctx,
-		"PUT",
-		fmt.Sprintf("/v1/webauthn/%s", body.WebAuthnRegistrationID),
-		nil,
-		jsonBody,
-		&retVal,
-		headers,
+		stytch.RequestParams{
+			Method:      "PUT",
+			Path:        fmt.Sprintf("/v1/webauthn/%s", body.WebAuthnRegistrationID),
+			QueryParams: nil,
+			Body:        jsonBody,
+			V:           &retVal,
+			Headers:     headers,
+		},
 	)
 	return &retVal, err
 }


### PR DESCRIPTION
This PR modifies the `NewRequest` and `RawRequest` interfaces to use a `RequestParams` struct rather than accepting all of the arguments individually. This will make it easier to add new parameters in the future.

This is marked as a minor version change rather than major since the affected functions are only meant for internal use.

The only actual code changes are `stytch/stytch.go`. The rest are the autogenerated changes to usages of `NewRequest` and `RawRequest`, various docs updates, and a couple of new authentication factors.