### PR TITLE
Add IPGEO to DFP rules endpoint

### DIFF
--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "16.7.0"
+const APIVersion = "16.8.0"

--- a/stytch/consumer/fraud/rules/types.go
+++ b/stytch/consumer/fraud/rules/types.go
@@ -14,26 +14,25 @@ import (
 
 // SetParams: Request type for `Rules.Set`.
 type SetParams struct {
-	// Action: The action that should be returned by a fingerprint lookup for that fingerprint or ID with a
-	// `RULE_MATCH` reason. The following values are valid: `ALLOW`, `BLOCK`, `CHALLENGE`, or `NONE`. If a
-	// `NONE` action is specified, it will clear the stored rule.
+	// Action: The action that should be returned by a fingerprint lookup for that identifier with a
+	// `RULE_MATCH` reason. The following values are valid: `ALLOW`, `BLOCK`, `CHALLENGE`, or `NONE`. For
+	// country codes, `ALLOW` actions are not allowed. If a `NONE` action is specified, it will clear the
+	// stored rule.
 	Action fraud.RuleAction `json:"action,omitempty"`
-	// VisitorID: The visitor ID we want to set a rule for. Only one fingerprint or ID can be specified in the
-	// request.
+	// VisitorID: The visitor ID we want to set a rule for. Only one identifier can be specified in the request.
 	VisitorID string `json:"visitor_id,omitempty"`
-	// BrowserID: The browser ID we want to set a rule for. Only one fingerprint or ID can be specified in the
-	// request.
+	// BrowserID: The browser ID we want to set a rule for. Only one identifier can be specified in the request.
 	BrowserID string `json:"browser_id,omitempty"`
-	// VisitorFingerprint: The visitor fingerprint we want to set a rule for. Only one fingerprint or ID can be
+	// VisitorFingerprint: The visitor fingerprint we want to set a rule for. Only one identifier can be
 	// specified in the request.
 	VisitorFingerprint string `json:"visitor_fingerprint,omitempty"`
-	// BrowserFingerprint: The browser fingerprint we want to set a rule for. Only one fingerprint or ID can be
+	// BrowserFingerprint: The browser fingerprint we want to set a rule for. Only one identifier can be
 	// specified in the request.
 	BrowserFingerprint string `json:"browser_fingerprint,omitempty"`
-	// HardwareFingerprint: The hardware fingerprint we want to set a rule for. Only one fingerprint or ID can
-	// be specified in the request.
+	// HardwareFingerprint: The hardware fingerprint we want to set a rule for. Only one identifier can be
+	// specified in the request.
 	HardwareFingerprint string `json:"hardware_fingerprint,omitempty"`
-	// NetworkFingerprint: The network fingerprint we want to set a rule for. Only one fingerprint or ID can be
+	// NetworkFingerprint: The network fingerprint we want to set a rule for. Only one identifier can be
 	// specified in the request.
 	NetworkFingerprint string `json:"network_fingerprint,omitempty"`
 	// ExpiresInMinutes: The number of minutes until this rule expires. If no `expires_in_minutes` is
@@ -41,6 +40,17 @@ type SetParams struct {
 	ExpiresInMinutes int32 `json:"expires_in_minutes,omitempty"`
 	// Description: An optional description for the rule.
 	Description string `json:"description,omitempty"`
+	// CidrBlock: The CIDR block we want to set a rule for. You may pass either an IP address or a CIDR block.
+	// The CIDR block prefix must be between 16 and 32, inclusive. If an end user's IP address is within this
+	// CIDR block, this rule will be applied. Only one identifier can be specified in the request.
+	CidrBlock string `json:"cidr_block,omitempty"`
+	// CountryCode: The country code we want to set a rule for. The country code must be a valid ISO 3166-1
+	// alpha-2 code. You may not set `ALLOW` rules for country codes. Only one identifier can be specified in
+	// the request.
+	CountryCode string `json:"country_code,omitempty"`
+	// Asn: The ASN we want to set a rule for. The ASN must be the string representation of an integer between
+	// 0 and 4294967295, inclusive. Only one identifier can be specified in the request.
+	Asn string `json:"asn,omitempty"`
 }
 
 // SetResponse: Response type for `Rules.Set`.
@@ -55,20 +65,26 @@ type SetResponse struct {
 	// patterns, e.g. 2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX
 	// are server errors.
 	StatusCode int32 `json:"status_code,omitempty"`
-	// VisitorID: The cookie stored on the user's device that uniquely identifies them.
+	// VisitorID: The visitor ID that a rule was set for.
 	VisitorID string `json:"visitor_id,omitempty"`
-	// BrowserID: Combination of VisitorID and NetworkFingerprint to create a clear identifier of a browser.
+	// BrowserID: The browser ID that a rule was set for.
 	BrowserID string `json:"browser_id,omitempty"`
-	// VisitorFingerprint: Cookie-less way of identifying a unique user.
+	// VisitorFingerprint: The visitor fingerprint that a rule was set for.
 	VisitorFingerprint string `json:"visitor_fingerprint,omitempty"`
-	// BrowserFingerprint: Combination of signals to identify a browser and its specific version.
+	// BrowserFingerprint: The browser fingerprint that a rule was set for.
 	BrowserFingerprint string `json:"browser_fingerprint,omitempty"`
-	// HardwareFingerprint: Combinations of signals to identify an operating system and architecture.
+	// HardwareFingerprint: The hardware fingerprint that a rule was set for.
 	HardwareFingerprint string `json:"hardware_fingerprint,omitempty"`
-	// NetworkFingerprint: Combination of signals associated with a specific network commonly known as TLS
-	// fingerprinting.
+	// NetworkFingerprint: The network fingerprint that a rule was set for.
 	NetworkFingerprint string `json:"network_fingerprint,omitempty"`
 	// ExpiresAt: The timestamp when the rule expires. Values conform to the RFC 3339 standard and are
 	// expressed in UTC, e.g. `2021-12-29T12:33:09Z`.
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	// CidrBlock: The CIDR block that a rule was set for. If an end user's IP address is within this CIDR
+	// block, this rule will be applied.
+	CidrBlock string `json:"cidr_block,omitempty"`
+	// CountryCode: The country code that a rule was set for.
+	CountryCode string `json:"country_code,omitempty"`
+	// Asn: The ASN that a rule was set for.
+	Asn string `json:"asn,omitempty"`
 }

--- a/stytch/consumer/fraud/types.go
+++ b/stytch/consumer/fraud/types.go
@@ -100,6 +100,12 @@ type Verdict struct {
 	// IsAuthenticDevice: The assessment of whether this is an authentic device. It will be false if hardware
 	// or browser deception is detected.
 	IsAuthenticDevice bool `json:"is_authentic_device,omitempty"`
+	// RuleMatchType: The type of rule match that was applied (e.g. `VISITOR_ID`), if any. This field will only
+	// be present if there is a `RULE_MATCH` reason in the list of verdict reasons.
+	RuleMatchType *RuleType `json:"rule_match_type,omitempty"`
+	// RuleMatchIdentifier: The rule that was applied (e.g. a specific visitor ID value), if any. This field
+	// will only be present if there is a `RULE_MATCH` reason in the list of verdict reasons.
+	RuleMatchIdentifier string `json:"rule_match_identifier,omitempty"`
 }
 
 type RuleAction string
@@ -109,6 +115,20 @@ const (
 	RuleActionCHALLENGE RuleAction = "CHALLENGE"
 	RuleActionBLOCK     RuleAction = "BLOCK"
 	RuleActionNONE      RuleAction = "NONE"
+)
+
+type RuleType string
+
+const (
+	RuleTypeVISITORID           RuleType = "VISITOR_ID"
+	RuleTypeBROWSERID           RuleType = "BROWSER_ID"
+	RuleTypeVISITORFINGERPRINT  RuleType = "VISITOR_FINGERPRINT"
+	RuleTypeBROWSERFINGERPRINT  RuleType = "BROWSER_FINGERPRINT"
+	RuleTypeHARDWAREFINGERPRINT RuleType = "HARDWARE_FINGERPRINT"
+	RuleTypeNETWORKFINGERPRINT  RuleType = "NETWORK_FINGERPRINT"
+	RuleTypeCIDRBLOCK           RuleType = "CIDR_BLOCK"
+	RuleTypeASN                 RuleType = "ASN"
+	RuleTypeCOUNTRYCODE         RuleType = "COUNTRY_CODE"
 )
 
 type VerdictAction string

--- a/stytch/consumer/fraud_rules.go
+++ b/stytch/consumer/fraud_rules.go
@@ -26,14 +26,25 @@ func NewFraudRulesClient(c stytch.Client) *FraudRulesClient {
 }
 
 // Set a rule for a particular `visitor_id`, `browser_id`, `visitor_fingerprint`, `browser_fingerprint`,
-// `hardware_fingerprint`, or `network_fingerprint`. This is helpful in cases where you want to allow or
-// block a specific user or fingerprint. You should be careful when setting rules for
-// `browser_fingerprint`, `hardware_fingerprint`, or `network_fingerprint` as they can be shared across
-// multiple users, and you could affect more users than intended.
+// `hardware_fingerprint`, `network_fingerprint`, `cidr_block`, `asn`, or `country_code`. This is helpful
+// in cases where you want to allow or block a specific user or fingerprint. You should be careful when
+// setting rules for `browser_fingerprint`, `hardware_fingerprint`, or `network_fingerprint` as they can be
+// shared across multiple users, and you could affect more users than intended.
+//
+// You may not set an `ALLOW` rule for a `country_code`.
 //
 // Rules are applied in the order specified above. For example, if an end user has an `ALLOW` rule set for
 // their `visitor_id` but a `BLOCK` rule set for their `hardware_fingerprint`, they will receive an `ALLOW`
 // verdict because the `visitor_id` rule takes precedence.
+//
+// If there are conflicts between multiple `cidr_block` rules (for example, if the `ip_address` of the end
+// user overlaps with multiple CIDR blocks that have rules set), the conflicts are resolved as follows:
+// - The smallest block size takes precedence. For example, if an `ip_address` overlaps with a `cidr_block`
+// rule of `ALLOW` for a block with a prefix of `/32` and a `cidr_block` rule of `BLOCK` with a prefix of
+// `/24`, the rule match verdict will be `ALLOW`.
+// - Among equivalent size blocks, `BLOCK` takes precedence over `CHALLENGE`, which takes precedence over
+// `ALLOW`. For example, if an `ip_address` overlaps with two `cidr_block` rules with blocks of the same
+// size that return `CHALLENGE` and `ALLOW`, the rule match verdict will be `CHALLENGE`.
 func (c *FraudRulesClient) Set(
 	ctx context.Context,
 	body *rules.SetParams,


### PR DESCRIPTION
This PR adds support for IPGEO in the fraud rules endpoint. You can now set rules on CIDR blocks, ASNs, and country codes. The fingerprint lookup endpoint will now also return information on which rule type and identifier were applied, if a `RULE_MATCH` reason was returned.