### PR TITLE
Remove `lll` from lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,14 +5,8 @@ run:
 linters-settings:
   goimports:
     local-prefixes: github.com/stytchauth/stytch-go/stytch
-  lll:
-    line-length: 200
 issues:
   exclude-rules:
-    # Ignore comments with long urls
-    - linters:
-        - lll
-      source: "^\\s*//\\s+https:"
     # Ignore false postitive hardcoded credentials warning in types.go
     - path: stytch/consumer/sessions/types.go
       text: "G101"
@@ -24,7 +18,6 @@ linters:
     - gofumpt
     - gosec
     - gosimple
-    - lll
     - misspell
     - sqlclosecheck
     - staticcheck


### PR DESCRIPTION
This was causing issues with auto-generated libraries.