### PR TITLE
Pipe error details through to stytch-go SDK

### DIFF
--- a/stytch/consumer/m2m_test.go
+++ b/stytch/consumer/m2m_test.go
@@ -186,7 +186,7 @@ func TestM2MClient_AuthenticateToken(t *testing.T) {
 			AccessToken:    token,
 			RequiredScopes: []string{"write:users"},
 		})
-		assert.ErrorIs(t, err, stytcherror.NewM2MPermissionError())
+		assert.ErrorContains(t, err, stytcherror.NewM2MPermissionError().Error())
 		assert.Nil(t, s)
 	})
 

--- a/stytch/shared/rbac_local_test.go
+++ b/stytch/shared/rbac_local_test.go
@@ -84,7 +84,7 @@ func TestPerformAuthorizationCheck(t *testing.T) {
 				Action:         "read",
 			},
 		)
-		assert.ErrorIs(t, err, stytcherror.NewSessionAuthorizationTenancyError(orgID, diffOrgID))
+		assert.ErrorContains(t, err, stytcherror.NewSessionAuthorizationTenancyError(orgID, diffOrgID).Error())
 	})
 	t.Run("action exists but resource does not", func(t *testing.T) {
 		err := shared.PerformAuthorizationCheck(
@@ -97,7 +97,7 @@ func TestPerformAuthorizationCheck(t *testing.T) {
 				Action:         "read",
 			},
 		)
-		assert.ErrorIs(t, err, stytcherror.NewPermissionError())
+		assert.ErrorContains(t, err, stytcherror.NewPermissionError().Error())
 	})
 	t.Run("resource exists but action does not", func(t *testing.T) {
 		err := shared.PerformAuthorizationCheck(
@@ -110,7 +110,7 @@ func TestPerformAuthorizationCheck(t *testing.T) {
 				Action:         "action_that_doesnt_exist",
 			},
 		)
-		assert.ErrorIs(t, err, stytcherror.NewPermissionError())
+		assert.ErrorContains(t, err, stytcherror.NewPermissionError().Error())
 	})
 	t.Run("member has this action but on a different resource", func(t *testing.T) {
 		err := shared.PerformAuthorizationCheck(
@@ -123,7 +123,7 @@ func TestPerformAuthorizationCheck(t *testing.T) {
 				Action:         "write",
 			},
 		)
-		assert.ErrorIs(t, err, stytcherror.NewPermissionError())
+		assert.ErrorContains(t, err, stytcherror.NewPermissionError().Error())
 	})
 	t.Run("another authorization check for a member with more elevated privileges", func(t *testing.T) {
 		err := shared.PerformAuthorizationCheck(
@@ -136,7 +136,7 @@ func TestPerformAuthorizationCheck(t *testing.T) {
 				Action:         "edit",
 			},
 		)
-		assert.ErrorIs(t, err, stytcherror.NewPermissionError())
+		assert.ErrorContains(t, err, stytcherror.NewPermissionError().Error())
 	})
 	t.Run("no error when the member is authorized", func(t *testing.T) {
 		err := shared.PerformAuthorizationCheck(

--- a/stytch/stytcherror/stytcherror.go
+++ b/stytch/stytcherror/stytcherror.go
@@ -14,12 +14,14 @@ type Error struct {
 	ErrorType    Type    `json:"error_type,omitempty"`
 	ErrorMessage Message `json:"error_message,omitempty"`
 	ErrorURL     URL     `json:"error_url,omitempty"`
+	ErrorDetails Details `json:"error_details,omitempty"`
 }
 
 type (
 	Type    string
 	Message string
 	URL     string
+	Details map[string]string
 )
 
 func (e Error) Error() string {
@@ -35,6 +37,9 @@ func (e Error) Error() string {
 
 	if e.ErrorURL != "" {
 		fmt.Fprintf(&es, " error_url: %s", e.ErrorURL)
+	}
+	if e.ErrorDetails != nil {
+		fmt.Fprintf(&es, " error_details: %v", e.ErrorDetails)
 	}
 	return es.String()
 }


### PR DESCRIPTION
Error details are used on stytcherrors to provide more info. I added error details to the invalid_email_for_jit_provisioning error in the API code, and piped them through to replay errors, but they still need to be added in the SDK code. This adds it for the GO code.

Testing:
I created a simple go app that hit my local version of the SDK and confirmed when I use an invalid email I see the error details now:
![Screenshot 2025-04-14 at 1 48 14 PM](https://github.com/user-attachments/assets/7489f36a-9a41-4321-862b-a1bd74f2865b)
