### PR TITLE
Updates Issuer Validation to Fallback to BaseURI

### DIFF
--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
@@ -92,7 +93,7 @@ func WithBaseURI(uri string) Option {
 	return func(api *API) {
 		api.baseURI = config.BaseURI(uri)
 		if defaultClient, ok := api.client.(*stytch.DefaultClient); ok {
-			defaultClient.Config.BaseURI = config.BaseURI(uri)
+			defaultClient.Config.BaseURI = config.BaseURI(strings.TrimSuffix(uri, "/"))
 		}
 	}
 }

--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -83,8 +83,8 @@ func WithHTTPClient(client *http.Client) Option {
 // WithBaseURI overrides the client base URI determined by the environment.
 //
 // The value derived from stytch.EnvLive or stytch.EnvTest is already correct for production use
-// in the Live or Test environment, respectively. This is implemented to make it easier to use
-// this client to access internal development versions of the API.
+// in the Live or Test environment, respectively. This is implemented to enable pointing requests at a CNAMEd URL
+// of your choice or to use this client to access internal development versions of the API.
 //
 // NOTE: You should not use this in conjunction with the WithClient option since WithClient completely overrides the
 // stytch.Client with one that may not be a stytch.DefaultClient.

--- a/stytch/b2b/sessions.go
+++ b/stytch/b2b/sessions.go
@@ -469,10 +469,6 @@ func (c *SessionsClient) AuthenticateJWTLocal(
 		return nil, stytcherror.ErrJWKSNotInitialized
 	}
 
-	aud := c.C.GetConfig().ProjectID
-	iss := fmt.Sprintf("stytch.com/%s", c.C.GetConfig().ProjectID)
-	fallbackIssuer := c.C.GetConfig().BaseURI
-
 	// It's difficult to extract all sets of claims (standard/registered, Stytch, custom) all at
 	// once. So we parse the token twice.
 	//
@@ -481,7 +477,14 @@ func (c *SessionsClient) AuthenticateJWTLocal(
 	//
 	// The second parse is for extracting the custom claims.
 	var staticClaims sessions.Claims
-	err := shared.ValidateJWTToken(token, &staticClaims, c.JWKS.Keyfunc, aud, iss, string(fallbackIssuer))
+	err := shared.ValidateJWTToken(shared.ValidateJWTTokenParams{
+		Token:          token,
+		StaticClaims:   &staticClaims,
+		KeyFunc:        c.JWKS.Keyfunc,
+		Audience:       c.C.GetConfig().ProjectID,
+		Issuer:         fmt.Sprintf("stytch.com/%s", c.C.GetConfig().ProjectID),
+		FallbackIssuer: string(c.C.GetConfig().BaseURI),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "16.16.0"
+const APIVersion = "16.16.1"

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "16.16.1"
+const APIVersion = "16.17.0"

--- a/stytch/consumer/m2m.go
+++ b/stytch/consumer/m2m.go
@@ -149,10 +149,14 @@ func (c *M2MClient) AuthenticateToken(
 
 	var claims jwt.MapClaims
 
-	aud := c.C.GetConfig().ProjectID
-	iss := fmt.Sprintf("stytch.com/%s", c.C.GetConfig().ProjectID)
-	fallbackIssuer := c.C.GetConfig().BaseURI
-	err := shared.ValidateJWTToken(req.AccessToken, &claims, c.JWKS.Keyfunc, aud, iss, string(fallbackIssuer))
+	err := shared.ValidateJWTToken(shared.ValidateJWTTokenParams{
+		Token:          req.AccessToken,
+		StaticClaims:   &claims,
+		KeyFunc:        c.JWKS.Keyfunc,
+		Audience:       c.C.GetConfig().ProjectID,
+		Issuer:         fmt.Sprintf("stytch.com/%s", c.C.GetConfig().ProjectID),
+		FallbackIssuer: string(c.C.GetConfig().BaseURI),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/stytch/consumer/m2m.go
+++ b/stytch/consumer/m2m.go
@@ -151,10 +151,10 @@ func (c *M2MClient) AuthenticateToken(
 
 	aud := c.C.GetConfig().ProjectID
 	iss := fmt.Sprintf("stytch.com/%s", c.C.GetConfig().ProjectID)
-
-	_, err := jwt.ParseWithClaims(req.AccessToken, &claims, c.JWKS.Keyfunc, jwt.WithAudience(aud), jwt.WithIssuer(iss))
+	fallbackIssuer := c.C.GetConfig().BaseURI
+	err := shared.ValidateJWTToken(req.AccessToken, &claims, c.JWKS.Keyfunc, aud, iss, string(fallbackIssuer))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse JWT: %w", err)
+		return nil, err
 	}
 
 	if req.MaxTokenAge != 0 {

--- a/stytch/consumer/m2m_test.go
+++ b/stytch/consumer/m2m_test.go
@@ -96,7 +96,7 @@ func TestM2MClient_AuthenticateToken(t *testing.T) {
 	client := &stytch.DefaultClient{
 		Config: &config.Config{
 			Env:       config.EnvTest,
-			BaseURI:   "https://example.test/v1/",
+			BaseURI:   "https://example.test/v1",
 			ProjectID: "project-test-00000000-0000-0000-0000-000000000000",
 			Secret:    "secret-test-11111111-1111-1111-1111-111111111111",
 		},
@@ -172,6 +172,25 @@ func TestM2MClient_AuthenticateToken(t *testing.T) {
 		})
 		assert.ErrorIs(t, err, jwt.ErrTokenInvalidIssuer)
 		assert.Nil(t, s)
+	})
+
+	t.Run("fallback issuer matches", func(t *testing.T) {
+		// We run into this case when a customer is using a custom base URI (usually a CNAME pointing at the Stytch API).
+		// Instead of returning the `stytch.com/<project_id>` issuer for CNAMEd domains, we return the URL they used to
+		// make the request. This is in line with the OIDC spec, which states that the issuer should match the URLs used to
+		// make requests.
+		iat := time.Now().UTC().Truncate(time.Second)
+		exp := iat.Add(time.Hour)
+
+		claims := sandboxM2MClaims(t, iat, exp, "read:users")
+		claims["iss"] = "https://example.test/v1"
+
+		token := signJWT(t, keyID, key, claims)
+
+		_, err := m2mClient.AuthenticateToken(context.Background(), &m2m.AuthenticateTokenParams{
+			AccessToken: token,
+		})
+		assert.NoError(t, err)
 	})
 
 	t.Run("missing scopes", func(t *testing.T) {

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -395,9 +395,9 @@ func (c *SessionsClient) AuthenticateJWTLocal(
 	//
 	// The second parse is for extracting the custom claims.
 	var staticClaims sessions.Claims
-	_, err := jwt.ParseWithClaims(token, &staticClaims, c.JWKS.Keyfunc, jwt.WithAudience(aud), jwt.WithIssuer(iss))
+	err := shared.ValidateJWTToken(token, &staticClaims, c.JWKS.Keyfunc, aud, iss, string(c.C.GetConfig().BaseURI))
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse JWT: %w", err)
+		return nil, err
 	}
 
 	if staticClaims.RegisteredClaims.IssuedAt.Add(maxTokenAge).Before(time.Now()) {

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -384,9 +384,6 @@ func (c *SessionsClient) AuthenticateJWTLocal(
 		return nil, stytcherror.ErrJWKSNotInitialized
 	}
 
-	aud := c.C.GetConfig().ProjectID
-	iss := fmt.Sprintf("stytch.com/%s", c.C.GetConfig().ProjectID)
-
 	// It's difficult to extract all sets of claims (standard/registered, Stytch, custom) all at
 	// once. So we parse the token twice.
 	//
@@ -395,7 +392,14 @@ func (c *SessionsClient) AuthenticateJWTLocal(
 	//
 	// The second parse is for extracting the custom claims.
 	var staticClaims sessions.Claims
-	err := shared.ValidateJWTToken(token, &staticClaims, c.JWKS.Keyfunc, aud, iss, string(c.C.GetConfig().BaseURI))
+	err := shared.ValidateJWTToken(shared.ValidateJWTTokenParams{
+		Token:          token,
+		StaticClaims:   &staticClaims,
+		KeyFunc:        c.JWKS.Keyfunc,
+		Audience:       c.C.GetConfig().ProjectID,
+		Issuer:         fmt.Sprintf("stytch.com/%s", c.C.GetConfig().ProjectID),
+		FallbackIssuer: string(c.C.GetConfig().BaseURI),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/stytch/consumer/sessions_test.go
+++ b/stytch/consumer/sessions_test.go
@@ -29,7 +29,7 @@ func TestAuthenticateJWTLocal(t *testing.T) {
 	client := &stytch.DefaultClient{
 		Config: &config.Config{
 			Env:       config.EnvTest,
-			BaseURI:   "https://example.test/v1/",
+			BaseURI:   "https://example.test/v1",
 			ProjectID: "project-test-00000000-0000-0000-0000-000000000000",
 			Secret:    "secret-test-11111111-1111-1111-1111-111111111111",
 		},
@@ -96,6 +96,24 @@ func TestAuthenticateJWTLocal(t *testing.T) {
 		s, err := sessionClient.AuthenticateJWTLocal(token, 1*time.Minute)
 		assert.ErrorIs(t, err, jwt.ErrTokenInvalidIssuer)
 		assert.Nil(t, s)
+	})
+
+	t.Run("fallback issuer matches", func(t *testing.T) {
+		// We run into this case when a customer is using a custom base URI (usually a CNAME pointing at the Stytch API).
+		// Instead of returning the `stytch.com/<project_id>` issuer for CNAMEd domains, we return the URL they used to
+		// make the request. This is in line with the OIDC spec, which states that the issuer should match the URLs used to
+		// make requests.
+
+		iat := time.Now().UTC().Truncate(time.Second)
+		exp := iat.Add(time.Hour)
+
+		claims := sandboxClaims(t, iat, exp)
+		claims.Issuer = "https://example.test/v1"
+
+		token := signJWT(t, keyID, key, claims)
+
+		_, err := sessionClient.AuthenticateJWTLocal(token, 1*time.Minute)
+		assert.NoError(t, err)
 	})
 
 	t.Run("valid JWT", func(t *testing.T) {

--- a/stytch/consumer/stytchapi/stytchapi.go
+++ b/stytch/consumer/stytchapi/stytchapi.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/MicahParks/keyfunc/v2"
@@ -88,7 +89,7 @@ func WithBaseURI(uri string) Option {
 	return func(api *API) {
 		api.baseURI = config.BaseURI(uri)
 		if defaultClient, ok := api.client.(*stytch.DefaultClient); ok {
-			defaultClient.Config.BaseURI = config.BaseURI(uri)
+			defaultClient.Config.BaseURI = config.BaseURI(strings.TrimSuffix(uri, "/"))
 		}
 	}
 }

--- a/stytch/consumer/stytchapi/stytchapi.go
+++ b/stytch/consumer/stytchapi/stytchapi.go
@@ -79,8 +79,8 @@ func WithHTTPClient(client *http.Client) Option {
 // WithBaseURI overrides the client base URI determined by the environment.
 //
 // The value derived from stytch.EnvLive or stytch.EnvTest is already correct for production use
-// in the Live or Test environment, respectively. This is implemented to make it easier to use
-// this client to access internal development versions of the API.
+// in the Live or Test environment, respectively. This is implemented to enable pointing requests at a CNAMEd URL
+// of your choice or to use this client to access internal development versions of the API.
 //
 // NOTE: You should not use this in conjunction with the WithClient option since WithClient completely overrides the
 // stytch.Client with one that may not be a stytch.DefaultClient.

--- a/stytch/shared/jwt.go
+++ b/stytch/shared/jwt.go
@@ -1,6 +1,10 @@
 package shared
 
-import "strings"
+import (
+	"fmt"
+	"github.com/golang-jwt/jwt/v5"
+	"strings"
+)
 
 // ReservedClaim returns true if the key is reserved by the JWT standard or the Stytch platform.
 func ReservedClaim(key string) bool {
@@ -18,4 +22,20 @@ func ReservedClaim(key string) bool {
 
 	// Stytch-specific claims are scoped by a URL prefix.
 	return strings.HasPrefix(key, "https://stytch.com/")
+}
+
+func ValidateJWTToken(token string, staticClaims jwt.Claims, keyFunc jwt.Keyfunc, audience string, issuer string, fallbackIssuer string) error {
+	// If we fail the first parse, we try again with the fallback issuer.
+	// We need to do this because when a customer is using a custom base URI (usually a CNAME pointing at the Stytch API),
+	// instead of returning the usual `stytch.com/<project_id>` issuer, we return the URL they used to
+	// make the request. This is in line with the OIDC spec. Ideally we would've always returned the baseURI issuer, but
+	// that would've broken existing customers who are dependent on the `stytch.com/<project_id>`.
+	_, err := jwt.ParseWithClaims(token, staticClaims, keyFunc, jwt.WithAudience(audience), jwt.WithIssuer(issuer))
+	if err != nil {
+		_, err := jwt.ParseWithClaims(token, staticClaims, keyFunc, jwt.WithAudience(audience), jwt.WithIssuer(fallbackIssuer))
+		if err != nil {
+			return fmt.Errorf("failed to parse JWT: %w", err)
+		}
+	}
+	return nil
 }

--- a/stytch/shared/jwt.go
+++ b/stytch/shared/jwt.go
@@ -25,15 +25,24 @@ func ReservedClaim(key string) bool {
 	return strings.HasPrefix(key, "https://stytch.com/")
 }
 
-func ValidateJWTToken(token string, staticClaims jwt.Claims, keyFunc jwt.Keyfunc, audience string, issuer string, fallbackIssuer string) error {
+type ValidateJWTTokenParams struct {
+	Token          string
+	StaticClaims   jwt.Claims
+	KeyFunc        jwt.Keyfunc
+	Audience       string
+	Issuer         string
+	FallbackIssuer string
+}
+
+func ValidateJWTToken(params ValidateJWTTokenParams) error {
 	// If we fail the first parse, we try again with the fallback issuer.
 	// We need to do this because when a customer is using a custom base URI (usually a CNAME pointing at the Stytch API),
 	// instead of returning the usual `stytch.com/<project_id>` issuer, we return the URL they used to
 	// make the request. This is in line with the OIDC spec. Ideally we would've always returned the baseURI issuer, but
 	// that would've broken existing customers who are dependent on the `stytch.com/<project_id>`.
-	_, err := jwt.ParseWithClaims(token, staticClaims, keyFunc, jwt.WithAudience(audience), jwt.WithIssuer(issuer))
+	_, err := jwt.ParseWithClaims(params.Token, params.StaticClaims, params.KeyFunc, jwt.WithAudience(params.Audience), jwt.WithIssuer(params.Issuer))
 	if err != nil {
-		_, err := jwt.ParseWithClaims(token, staticClaims, keyFunc, jwt.WithAudience(audience), jwt.WithIssuer(fallbackIssuer))
+		_, err := jwt.ParseWithClaims(params.Token, params.StaticClaims, params.KeyFunc, jwt.WithAudience(params.Audience), jwt.WithIssuer(params.FallbackIssuer))
 		if err != nil {
 			return fmt.Errorf("failed to parse JWT: %w", err)
 		}

--- a/stytch/shared/jwt.go
+++ b/stytch/shared/jwt.go
@@ -2,8 +2,9 @@ package shared
 
 import (
 	"fmt"
-	"github.com/golang-jwt/jwt/v5"
 	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // ReservedClaim returns true if the key is reserved by the JWT standard or the Stytch platform.


### PR DESCRIPTION
We are in the process of changing the issuer that JWTs return to be the base URL of the request we received on `authenticate` (this is in line with the OIDC spec). We want to accept that issuer as well as the default one in our JWT local auth methods.