### PR TITLE
Small update the type of error details to allow for nested objects

### DIFF
--- a/stytch/stytcherror/stytcherror.go
+++ b/stytch/stytcherror/stytcherror.go
@@ -21,7 +21,7 @@ type (
 	Type    string
 	Message string
 	URL     string
-	Details map[string]string
+	Details map[string]any
 )
 
 func (e Error) Error() string {


### PR DESCRIPTION
Previously I had added Details to the Error object so that error details from the API would be piped through. However I added it as map[string]string which fails if it's a nested object. This changes it to map[string]any so it accounts for this.