### PR TITLE
Add IntrospectTokenLocal function for connected apps

### DIFF
--- a/stytch/b2b/b2bstytchapi/b2bstytchapi.go
+++ b/stytch/b2b/b2bstytchapi/b2bstytchapi.go
@@ -51,6 +51,7 @@ type API struct {
 	SSO           *b2b.SSOClient
 	Sessions      *b2b.SessionsClient
 	TOTPs         *b2b.TOTPsClient
+	IDP           *b2b.IDPClient
 }
 
 type Option func(*API)
@@ -174,6 +175,7 @@ func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
 	a.SSO = b2b.NewSSOClient(a.client)
 	a.Sessions = b2b.NewSessionsClient(a.client, jwks, policyCache)
 	a.TOTPs = b2b.NewTOTPsClient(a.client)
+	a.IDP = b2b.NewIDPClient(a.client, jwks, policyCache)
 
 	return a, nil
 }

--- a/stytch/b2b/idp.go
+++ b/stytch/b2b/idp.go
@@ -1,0 +1,100 @@
+package b2b
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MicahParks/keyfunc/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stytchauth/stytch-go/v16/stytch"
+	"github.com/stytchauth/stytch-go/v16/stytch/b2b/idp"
+	"github.com/stytchauth/stytch-go/v16/stytch/b2b/rbac"
+	"github.com/stytchauth/stytch-go/v16/stytch/b2b/sessions"
+	"github.com/stytchauth/stytch-go/v16/stytch/shared"
+	"github.com/stytchauth/stytch-go/v16/stytch/stytcherror"
+)
+
+type IDPClient struct {
+	C           stytch.Client
+	JWKS        *keyfunc.JWKS
+	PolicyCache *PolicyCache
+}
+
+func NewIDPClient(c stytch.Client, jwks *keyfunc.JWKS, policyCache *PolicyCache) *IDPClient {
+	return &IDPClient{
+		C:           c,
+		JWKS:        jwks,
+		PolicyCache: policyCache,
+	}
+}
+
+func (c *IDPClient) IntrospectTokenLocal(
+	ctx context.Context,
+	req *idp.IntrospectTokenLocalParams,
+) (*idp.IntrospectTokenClaims, error) {
+	if c.JWKS == nil {
+		return nil, stytcherror.ErrJWKSNotInitialized
+	}
+
+	var staticClaims idp.IntrospectTokenClaims
+	err := shared.ValidateJWTToken(shared.ValidateJWTTokenParams{
+		Token:          req.Token,
+		StaticClaims:   &staticClaims,
+		KeyFunc:        c.JWKS.Keyfunc,
+		Audience:       c.C.GetConfig().ProjectID,
+		Issuer:         fmt.Sprintf("stytch.com/%s", c.C.GetConfig().ProjectID),
+		FallbackIssuer: string(c.C.GetConfig().BaseURI),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if req.MaxTokenAge != 0 {
+		iat, err := staticClaims.GetIssuedAt()
+		if err != nil {
+			return nil, err
+		}
+		if iat.Add(req.MaxTokenAge).Before(time.Now()) {
+			// The JWT is valid, but older than the tolerable maximum age.
+			return nil, sessions.ErrJWTTooOld
+		}
+	}
+
+	// The token has already been verified at this point, so its claims and signature are all
+	// valid. This call to ParseUnverified is _only_ for extracting the remaining custom claims.
+	//
+	// Using ParseWithClaims again would cause this to re-validate the token's timestamps and
+	// signature, which fail if it was very close to its expiration on the previous parse.
+	var customClaims jwt.MapClaims
+	_, _, err = jwt.NewParser().ParseUnverified(req.Token, &customClaims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse access token: %w", err)
+	}
+
+	// Remove all the reserved claims that are already present in staticClaims.
+	for key := range customClaims {
+		if shared.ReservedClaim(key) {
+			delete(customClaims, key)
+		}
+	}
+	staticClaims.CustomClaims = customClaims
+
+	var policy *rbac.Policy
+	if req.AuthorizationCheck != nil {
+		policy, err = c.PolicyCache.Get(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cached policy: %w", err)
+		}
+
+		tokenScopes := strings.Split(strings.TrimSpace(staticClaims.Scope), " ")
+
+		err = shared.PerformScopeAuthorizationCheck(policy, tokenScopes, staticClaims.Organization.OrganizationID, req.AuthorizationCheck)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &staticClaims, nil
+}

--- a/stytch/b2b/idp/types.go
+++ b/stytch/b2b/idp/types.go
@@ -1,0 +1,31 @@
+package idp
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stytchauth/stytch-go/v16/stytch/b2b/sessions"
+)
+
+type OrganizationClaim struct {
+	OrganizationID string `json:"organization_id"`
+	Slug           string `json:"slug"`
+}
+
+type IntrospectTokenClaims struct {
+	Subject      string            `json:"sub"`
+	Scope        string            `json:"scope"`
+	CustomClaims map[string]any    `json:"custom_claims"`
+	ExpiresAt    int32             `json:"exp"`
+	IssuedAt     int32             `json:"iat"`
+	NotBefore    int32             `json:"nbf"`
+	TokenType    string            `json:"token_type"`
+	Organization OrganizationClaim `json:"https://stytch.com/organization"`
+	jwt.RegisteredClaims
+}
+
+type IntrospectTokenLocalParams struct {
+	Token              string
+	MaxTokenAge        time.Duration
+	AuthorizationCheck *sessions.AuthorizationCheck
+}

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "16.19.0"
+const APIVersion = "16.20.0"


### PR DESCRIPTION
This PR adds the `IntrospectTokenLocal` function under a new IDP client. This function can be used to introspect access tokens minted by our connected apps flow.