### PR TITLE
feat: [AUTH-5632] Add IntrospectTokenNetwork and fix IntrospectTokenLocal

### DIFF
--- a/stytch/b2b/idp.go
+++ b/stytch/b2b/idp.go
@@ -2,7 +2,12 @@ package b2b
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"github.com/stytchauth/stytch-go/v16/stytch/config"
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -30,14 +35,94 @@ func NewIDPClient(c stytch.Client, jwks *keyfunc.JWKS, policyCache *PolicyCache)
 	}
 }
 
+func (c *IDPClient) IntrospectTokenNetwork(
+	ctx context.Context,
+	body *idp.IntrospectTokenNetworkParams,
+) (*idp.IntrospectTokenResponse, error) {
+	cfg := c.C.GetConfig()
+	client := c.C.GetHTTPClient()
+	path := string(cfg.BaseURI) + "/v1/public/" + cfg.ProjectID + "/oauth2/introspect"
+
+	data := url.Values{}
+	data.Add("token", body.Token)
+	data.Add("client_id", body.ClientID)
+	if body.ClientSecret != nil {
+		data.Add("client_secret", *body.ClientSecret)
+	}
+	if body.TokenTypeHint != nil {
+		data.Add("token_type_hint", *body.TokenTypeHint)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", path, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("User-Agent", "Stytch Go v"+config.APIVersion)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error sending http request: %w", err)
+	}
+	defer func() {
+		res.Body.Close()
+	}()
+
+	bytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading http request: %w", err)
+	}
+
+	if res.StatusCode != 200 {
+		// Attempt to unmarshal into Stytch error format
+		var stytchErr stytcherror.OAuth2Error
+		if err = json.Unmarshal(bytes, &stytchErr); err != nil {
+			return nil, fmt.Errorf("error decoding http request: %w", err)
+		}
+		stytchErr.StatusCode = res.StatusCode
+		return nil, stytchErr
+	}
+
+	var tokenRes idp.IntrospectTokenResponse
+	if err = json.Unmarshal(bytes, &tokenRes); err != nil {
+		return nil, fmt.Errorf("error decoding http request: %w", err)
+	}
+	if !tokenRes.Active {
+		return nil, stytcherror.NewInvalidOAuth2TokenError()
+	}
+	if body.AuthorizationCheck != nil {
+		policy, err := c.PolicyCache.Get(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cached policy: %w", err)
+		}
+
+		tokenScopes := strings.Split(strings.TrimSpace(tokenRes.Scope), " ")
+
+		err = shared.PerformScopeAuthorizationCheck(policy, tokenScopes, tokenRes.Organization.OrganizationID, body.AuthorizationCheck)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &tokenRes, nil
+}
+
 func (c *IDPClient) IntrospectTokenLocal(
 	ctx context.Context,
 	req *idp.IntrospectTokenLocalParams,
-) (*idp.IntrospectTokenClaims, error) {
+) (*idp.IntrospectTokenResponse, error) {
 	if c.JWKS == nil {
 		return nil, stytcherror.ErrJWKSNotInitialized
 	}
 
+	// It's difficult to extract all sets of claims (standard/registered, Stytch, custom) all at
+	// once. So we parse the token twice.
+	//
+	// The first parse is for validating and extracting the statically-known claims. It will fail
+	// if the token is invalid for any reason.
+	//
+	// The second parse is for extracting the custom claims.
 	var staticClaims idp.IntrospectTokenClaims
 	err := shared.ValidateJWTToken(shared.ValidateJWTTokenParams{
 		Token:          req.Token,
@@ -75,11 +160,10 @@ func (c *IDPClient) IntrospectTokenLocal(
 
 	// Remove all the reserved claims that are already present in staticClaims.
 	for key := range customClaims {
-		if shared.ReservedClaim(key) {
+		if shared.ReservedClaim(key) || key == "jti" || key == "scope" || key == "client_id" {
 			delete(customClaims, key)
 		}
 	}
-	staticClaims.CustomClaims = customClaims
 
 	var policy *rbac.Policy
 	if req.AuthorizationCheck != nil {
@@ -96,5 +180,21 @@ func (c *IDPClient) IntrospectTokenLocal(
 		}
 	}
 
-	return &staticClaims, nil
+	return marshalJWTIntoResponse(staticClaims, customClaims)
+}
+
+func marshalJWTIntoResponse(staticClaims idp.IntrospectTokenClaims, customClaims jwt.MapClaims) (*idp.IntrospectTokenResponse, error) {
+	return &idp.IntrospectTokenResponse{
+		Active:       true,
+		TokenType:    "access_token",
+		Issuer:       staticClaims.Issuer,
+		Subject:      staticClaims.Subject,
+		Audience:     staticClaims.Audience,
+		Scope:        staticClaims.Scope,
+		ClientID:     staticClaims.ClientID,
+		Expiry:       staticClaims.ExpiresAt,
+		IssuedAt:     staticClaims.IssuedAt,
+		Organization: staticClaims.Organization,
+		CustomClaims: customClaims,
+	}, nil
 }

--- a/stytch/b2b/idp/types.go
+++ b/stytch/b2b/idp/types.go
@@ -1,9 +1,9 @@
 package idp
 
 import (
+	"github.com/golang-jwt/jwt/v5"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/stytchauth/stytch-go/v16/stytch/b2b/sessions"
 )
 
@@ -12,20 +12,38 @@ type OrganizationClaim struct {
 	Slug           string `json:"slug"`
 }
 
-type IntrospectTokenClaims struct {
-	Subject      string            `json:"sub"`
-	Scope        string            `json:"scope"`
-	CustomClaims map[string]any    `json:"custom_claims"`
-	ExpiresAt    int32             `json:"exp"`
-	IssuedAt     int32             `json:"iat"`
-	NotBefore    int32             `json:"nbf"`
+type IntrospectTokenResponse struct {
+	Active       bool              `json:"active"`
 	TokenType    string            `json:"token_type"`
+	Issuer       string            `json:"iss"`
+	Subject      string            `json:"sub"`
+	Audience     []string          `json:"aud"`
+	Scope        string            `json:"scope"`
+	ClientID     string            `json:"client_id"`
+	Expiry       *jwt.NumericDate  `json:"exp"`
+	IssuedAt     *jwt.NumericDate  `json:"iat"`
 	Organization OrganizationClaim `json:"https://stytch.com/organization"`
+	CustomClaims map[string]any
+}
+
+type IntrospectTokenClaims struct {
+	ClientID     string            `json:"client_id"`
+	Scope        string            `json:"scope"`
+	Organization OrganizationClaim `json:"https://stytch.com/organization"`
+	JTI          string            `json:"jti"`
 	jwt.RegisteredClaims
 }
 
 type IntrospectTokenLocalParams struct {
 	Token              string
 	MaxTokenAge        time.Duration
+	AuthorizationCheck *sessions.AuthorizationCheck
+}
+
+type IntrospectTokenNetworkParams struct {
+	Token              string
+	ClientID           string
+	ClientSecret       *string
+	TokenTypeHint      *string
 	AuthorizationCheck *sessions.AuthorizationCheck
 }

--- a/stytch/b2b/idp_test.go
+++ b/stytch/b2b/idp_test.go
@@ -1,0 +1,194 @@
+package b2b_test
+
+import (
+	"context"
+	"github.com/MicahParks/keyfunc/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stytchauth/stytch-go/v16/stytch"
+	"github.com/stytchauth/stytch-go/v16/stytch/b2b"
+	"github.com/stytchauth/stytch-go/v16/stytch/b2b/idp"
+	"github.com/stytchauth/stytch-go/v16/stytch/config"
+	"github.com/stytchauth/stytch-go/v16/stytch/stytcherror"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestIDP_IntrospectTokenNetwork(t *testing.T) {
+	client := &stytch.DefaultClient{
+		Config: &config.Config{
+			ProjectID: "some-project-id-0000-000-000-0000",
+		},
+		HTTPClient: http.DefaultClient,
+	}
+	expectedToken := "expectedToken"
+	expectedClientID := "mock_client_id"
+	expectedClientSecret := "mock_client_id"
+
+	t.Run("sends token request", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/v1/public/some-project-id-0000-000-000-0000/oauth2/introspect", r.URL.Path)
+			assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("content-type"))
+			bytes, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			params, err := url.ParseQuery(string(bytes))
+			require.NoError(t, err)
+
+			assert.Equal(t, expectedClientID, params.Get("client_id"))
+			assert.Equal(t, expectedClientSecret, params.Get("client_secret"))
+			assert.Equal(t, expectedToken, params.Get("token"))
+
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write([]byte(`{
+				"active": true,
+				"aud": ["project-test-0000-000-000-0000"],
+				"client_id": "connected-app-test-0000-000-000-0000",
+				"exp": 1738848103,
+				"iat": 1738844503,
+				"iss": "https://upn.customers.stytch.dev",
+				"scope": "openid email profile",
+				"sub": "member-test-0000-000-000-0000",
+				"token_type": "access_token",
+				"https://stytch.com/organization": {
+					"organization_id": "org-test-0000-000-000-0000",
+					"slug": "some-slug"
+				}
+			}`))
+			assert.NoError(t, err)
+		}))
+
+		client.Config.BaseURI = config.BaseURI(svr.URL)
+
+		res, err := b2b.NewIDPClient(client, nil, nil).
+			IntrospectTokenNetwork(context.Background(), &idp.IntrospectTokenNetworkParams{
+				Token:        expectedToken,
+				ClientID:     expectedClientID,
+				ClientSecret: &expectedClientSecret,
+			})
+		require.NoError(t, err)
+
+		expected := &idp.IntrospectTokenResponse{
+			Active:       true,
+			TokenType:    "access_token",
+			Issuer:       "https://upn.customers.stytch.dev",
+			Subject:      "member-test-0000-000-000-0000",
+			Audience:     []string{"project-test-0000-000-000-0000"},
+			Scope:        "openid email profile",
+			CustomClaims: nil,
+			ClientID:     "connected-app-test-0000-000-000-0000",
+			Organization: idp.OrganizationClaim{
+				OrganizationID: "org-test-0000-000-000-0000",
+				Slug:           "some-slug",
+			},
+			Expiry:   res.Expiry,
+			IssuedAt: res.IssuedAt,
+		}
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("handles inactive token response", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{
+				"active": false
+			}`))
+			assert.NoError(t, err)
+		}))
+
+		client.Config.BaseURI = config.BaseURI(svr.URL)
+
+		_, err := b2b.NewIDPClient(client, nil, nil).
+			IntrospectTokenNetwork(context.Background(), &idp.IntrospectTokenNetworkParams{
+				Token:        expectedToken,
+				ClientID:     expectedClientID,
+				ClientSecret: &expectedClientSecret,
+			})
+		assert.EqualError(t, err, stytcherror.NewInvalidOAuth2TokenError().Error())
+	})
+
+	t.Run("handles error response", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, err := w.Write([]byte(`{ "error":"invalid_client" }`))
+			assert.NoError(t, err)
+		}))
+
+		client.Config.BaseURI = config.BaseURI(svr.URL)
+
+		res, err := b2b.NewIDPClient(client, nil, nil).
+			IntrospectTokenNetwork(context.Background(), &idp.IntrospectTokenNetworkParams{
+				Token:        expectedToken,
+				ClientID:     expectedClientID,
+				ClientSecret: &expectedClientSecret,
+			})
+		assert.Nil(t, res)
+		var stytchErr stytcherror.OAuth2Error
+		assert.ErrorAs(t, err, &stytchErr)
+	})
+}
+
+func TestIDP_IntrospectTokenLocal(t *testing.T) {
+	client := &stytch.DefaultClient{
+		Config: &config.Config{
+			ProjectID: "project-test-0000-000-000-0000",
+		},
+		// In these tests, the keyset has already been downloaded, so no other network requests
+		// should be made.
+		HTTPClient: nil,
+	}
+
+	key := rsaKey(t)
+	keyID := "jwk-test-22222222-2222-2222-2222-222222222222"
+	jwks := keyfunc.NewGiven(map[string]keyfunc.GivenKey{
+		keyID: keyfunc.NewGivenRSA(&key.PublicKey, keyfunc.GivenKeyOptions{Algorithm: "RS256"}),
+	})
+
+	policyCache := b2b.NewPolicyCache(b2b.NewRBACClient(client))
+	idpClient := b2b.NewIDPClient(client, jwks, policyCache)
+
+	t.Run("valid JWT", func(t *testing.T) {
+		token := signJWT(t, keyID, key, jwt.MapClaims{
+			"iss":       "https://upn.customers.stytch.dev",
+			"sub":       "member-test-0000-000-000-0000",
+			"aud":       []string{"project-test-0000-000-000-0000"},
+			"iat":       time.Now().Add(-time.Minute).Unix(),
+			"exp":       time.Now().Add(time.Minute).Unix(),
+			"client_id": "connected-app-test-0000-000-000-0000",
+			"scope":     "openid email profile",
+			"https://stytch.com/organization": map[string]string{
+				"organization_id": "org-test-0000-000-000-0000",
+				"slug":            "some-slug",
+			},
+		})
+
+		ctx := context.Background()
+		res, err := idpClient.IntrospectTokenLocal(ctx, &idp.IntrospectTokenLocalParams{
+			Token: token,
+		})
+		require.NoError(t, err)
+
+		expected := &idp.IntrospectTokenResponse{
+			Active:       true,
+			TokenType:    "access_token",
+			Issuer:       "https://upn.customers.stytch.dev",
+			Subject:      "member-test-0000-000-000-0000",
+			Audience:     []string{"project-test-0000-000-000-0000"},
+			Scope:        "openid email profile",
+			CustomClaims: map[string]any{},
+			ClientID:     "connected-app-test-0000-000-000-0000",
+			Organization: idp.OrganizationClaim{
+				OrganizationID: "org-test-0000-000-000-0000",
+				Slug:           "some-slug",
+			},
+			Expiry:   res.Expiry,
+			IssuedAt: res.IssuedAt,
+		}
+		assert.Equal(t, expected, res)
+	})
+}

--- a/stytch/stytcherror/stytcherror.go
+++ b/stytch/stytcherror/stytcherror.go
@@ -112,4 +112,14 @@ func NewM2MPermissionError() error {
 	}
 }
 
+func NewInvalidOAuth2TokenError() error {
+	msg := "The token introspected was not valid. It may be expired."
+	return Error{
+		StatusCode:   400,
+		ErrorType:    "oauth2_invalid_token_error",
+		ErrorMessage: Message(msg + ", v" + config.APIVersion),
+		ErrorURL:     "https://stytch.com/docs/api/errors/400",
+	}
+}
+
 var ErrJWKSNotInitialized = errors.New("JWKS not initialized")


### PR DESCRIPTION
This PR adds `IntrospectTokenNetwork` + tests and fixes a bug in `IntrospectTokenLocal` that was preventing it from properly parsing JWTs. Multiple fields wound up with the same `json` tag in the `IntrospectTokenClaims` struct due to embedding semantics.

This PR brings the JWT verification more in-line with other JWT verification patterns:
- We do not return the raw JWT claims, we return an object that abstracts over the core JWT structure
- We return the same object for both local and remove validation.

PR was validated with a local script performing both types of validation, in addition to existing tests:
```
	resNet, err := client.IDP.IntrospectTokenNetwork(context.Background(), &idp.IntrospectTokenNetworkParams{
		Token:        token,
		ClientID:     "connected-app-test-...",
		ClientSecret: nil,
	})
	fmt.Println(resNet, err)

	resLocal, err := client.IDP.IntrospectTokenLocal(context.Background(), &idp.IntrospectTokenLocalParams{
		Token: token,
	})
	fmt.Println(resLocal, err)
```

Nominally this is a breaking API change due to the fact that we are returning a different type, however it is in a beta product that _didn't work_ so I am happy to roll forward as a patch unless someone screams otherwise. 