### PR TITLE
feat: [AUTH-5632] Add Consumer IntrospectToken methods

### DIFF
--- a/stytch/consumer/idp.go
+++ b/stytch/consumer/idp.go
@@ -1,20 +1,198 @@
 package consumer
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
 	"github.com/MicahParks/keyfunc/v2"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stytchauth/stytch-go/v16/stytch"
+	"github.com/stytchauth/stytch-go/v16/stytch/config"
+	"github.com/stytchauth/stytch-go/v16/stytch/consumer/idp"
+	"github.com/stytchauth/stytch-go/v16/stytch/consumer/sessions"
+	"github.com/stytchauth/stytch-go/v16/stytch/shared"
+	"github.com/stytchauth/stytch-go/v16/stytch/stytcherror"
 )
 
 type IDPClient struct {
 	C           stytch.Client
 	JWKS        *keyfunc.JWKS
-	PolicyCache any
+	PolicyCache *PolicyCache
 }
 
-func NewIDPClient(c stytch.Client, jwks *keyfunc.JWKS, policyCache any) *IDPClient {
+func NewIDPClient(c stytch.Client, jwks *keyfunc.JWKS, policyCache *PolicyCache) *IDPClient {
 	return &IDPClient{
 		C:           c,
 		JWKS:        jwks,
 		PolicyCache: policyCache,
 	}
+}
+
+func (c *IDPClient) IntrospectTokenNetwork(
+	ctx context.Context,
+	body *idp.IntrospectTokenNetworkParams,
+) (*idp.IntrospectTokenResponse, error) {
+	cfg := c.C.GetConfig()
+	client := c.C.GetHTTPClient()
+	path := string(cfg.BaseURI) + "/v1/public/" + cfg.ProjectID + "/oauth2/introspect"
+
+	data := url.Values{}
+	data.Add("token", body.Token)
+	data.Add("client_id", body.ClientID)
+	if body.ClientSecret != nil {
+		data.Add("client_secret", *body.ClientSecret)
+	}
+	if body.TokenTypeHint != nil {
+		data.Add("token_type_hint", *body.TokenTypeHint)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", path, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("error creating http request: %w", err)
+	}
+
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("User-Agent", "Stytch Go v"+config.APIVersion)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error sending http request: %w", err)
+	}
+	defer func() {
+		res.Body.Close()
+	}()
+
+	bytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading http response: %w", err)
+	}
+
+	if res.StatusCode != 200 {
+		// Attempt to unmarshal into Stytch error format
+		var stytchErr stytcherror.OAuth2Error
+		if err = json.Unmarshal(bytes, &stytchErr); err != nil {
+			return nil, fmt.Errorf("error decoding http response: %w", err)
+		}
+		stytchErr.StatusCode = res.StatusCode
+		return nil, stytchErr
+	}
+
+	var tokenRes idp.IntrospectTokenResponse
+	if err = json.Unmarshal(bytes, &tokenRes); err != nil {
+		return nil, fmt.Errorf("error decoding http response: %w", err)
+	}
+	if !tokenRes.Active {
+		return nil, stytcherror.NewInvalidOAuth2TokenError()
+	}
+	//if body.AuthorizationCheck != nil {
+	//	policy, err := c.PolicyCache.Get(ctx)
+	//	if err != nil {
+	//		return nil, fmt.Errorf("failed to get cached policy: %w", err)
+	//	}
+	//
+	//	tokenScopes := strings.Split(strings.TrimSpace(tokenRes.Scope), " ")
+	//
+	//	err = shared.PerformScopeAuthorizationCheck(policy, tokenScopes, tokenRes.Organization.OrganizationID, body.AuthorizationCheck)
+	//	if err != nil {
+	//		return nil, err
+	//	}
+	//}
+
+	return &tokenRes, nil
+}
+
+func (c *IDPClient) IntrospectTokenLocal(
+	ctx context.Context,
+	req *idp.IntrospectTokenLocalParams,
+) (*idp.IntrospectTokenResponse, error) {
+	if c.JWKS == nil {
+		return nil, stytcherror.ErrJWKSNotInitialized
+	}
+
+	// It's difficult to extract all sets of claims (standard/registered, Stytch, custom) all at
+	// once. So we parse the token twice.
+	//
+	// The first parse is for validating and extracting the statically-known claims. It will fail
+	// if the token is invalid for any reason.
+	//
+	// The second parse is for extracting the custom claims.
+	var staticClaims idp.IntrospectTokenClaims
+	err := shared.ValidateJWTToken(shared.ValidateJWTTokenParams{
+		Token:          req.Token,
+		StaticClaims:   &staticClaims,
+		KeyFunc:        c.JWKS.Keyfunc,
+		Audience:       c.C.GetConfig().ProjectID,
+		Issuer:         fmt.Sprintf("stytch.com/%s", c.C.GetConfig().ProjectID),
+		FallbackIssuer: string(c.C.GetConfig().BaseURI),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if req.MaxTokenAge != 0 {
+		iat, err := staticClaims.GetIssuedAt()
+		if err != nil {
+			return nil, err
+		}
+		if iat.Add(req.MaxTokenAge).Before(time.Now()) {
+			// The JWT is valid, but older than the tolerable maximum age.
+			return nil, sessions.ErrJWTTooOld
+		}
+	}
+
+	// The token has already been verified at this point, so its claims and signature are all
+	// valid. This call to ParseUnverified is _only_ for extracting the remaining custom claims.
+	//
+	// Using ParseWithClaims again would cause this to re-validate the token's timestamps and
+	// signature, which fail if it was very close to its expiration on the previous parse.
+	var customClaims jwt.MapClaims
+	_, _, err = jwt.NewParser().ParseUnverified(req.Token, &customClaims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse access token: %w", err)
+	}
+
+	// Remove all the reserved claims that are already present in staticClaims.
+	for key := range customClaims {
+		if shared.ReservedClaim(key) || key == "jti" || key == "scope" || key == "client_id" {
+			delete(customClaims, key)
+		}
+	}
+
+	//var policy *rbac.Policy
+	//if req.AuthorizationCheck != nil {
+	//	policy, err = c.PolicyCache.Get(ctx)
+	//	if err != nil {
+	//		return nil, fmt.Errorf("failed to get cached policy: %w", err)
+	//	}
+	//
+	//	tokenScopes := strings.Split(strings.TrimSpace(staticClaims.Scope), " ")
+	//
+	//	err = shared.PerformScopeAuthorizationCheck(policy, tokenScopes, staticClaims.Organization.OrganizationID, req.AuthorizationCheck)
+	//	if err != nil {
+	//		return nil, err
+	//	}
+	//}
+
+	return marshalAccessTokenJWTIntoResponse(staticClaims, customClaims)
+}
+
+func marshalAccessTokenJWTIntoResponse(staticClaims idp.IntrospectTokenClaims, customClaims jwt.MapClaims) (*idp.IntrospectTokenResponse, error) {
+	return &idp.IntrospectTokenResponse{
+		Active:       true,
+		TokenType:    "access_token",
+		Issuer:       staticClaims.Issuer,
+		Subject:      staticClaims.Subject,
+		Audience:     staticClaims.Audience,
+		Scope:        staticClaims.Scope,
+		ClientID:     staticClaims.ClientID,
+		Expiry:       staticClaims.ExpiresAt,
+		IssuedAt:     staticClaims.IssuedAt,
+		CustomClaims: customClaims,
+	}, nil
 }

--- a/stytch/consumer/idp/types.go
+++ b/stytch/consumer/idp/types.go
@@ -1,0 +1,41 @@
+package idp
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type IntrospectTokenResponse struct {
+	Active       bool             `json:"active"`
+	TokenType    string           `json:"token_type"`
+	Issuer       string           `json:"iss"`
+	Subject      string           `json:"sub"`
+	Audience     []string         `json:"aud"`
+	Scope        string           `json:"scope"`
+	ClientID     string           `json:"client_id"`
+	Expiry       *jwt.NumericDate `json:"exp"`
+	IssuedAt     *jwt.NumericDate `json:"iat"`
+	CustomClaims map[string]any
+}
+
+type IntrospectTokenClaims struct {
+	ClientID string `json:"client_id"`
+	Scope    string `json:"scope"`
+	JTI      string `json:"jti"`
+	jwt.RegisteredClaims
+}
+
+type IntrospectTokenLocalParams struct {
+	Token       string
+	MaxTokenAge time.Duration
+	// AuthorizationCheck *sessions.AuthorizationCheck
+}
+
+type IntrospectTokenNetworkParams struct {
+	Token         string
+	ClientID      string
+	ClientSecret  *string
+	TokenTypeHint *string
+	// AuthorizationCheck *sessions.AuthorizationCheck
+}

--- a/stytch/consumer/idp_test.go
+++ b/stytch/consumer/idp_test.go
@@ -1,0 +1,180 @@
+package consumer_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stytchauth/stytch-go/v16/stytch/consumer"
+
+	"github.com/MicahParks/keyfunc/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stytchauth/stytch-go/v16/stytch"
+	"github.com/stytchauth/stytch-go/v16/stytch/config"
+	"github.com/stytchauth/stytch-go/v16/stytch/consumer/idp"
+	"github.com/stytchauth/stytch-go/v16/stytch/stytcherror"
+)
+
+func TestIDP_IntrospectTokenNetwork(t *testing.T) {
+	client := &stytch.DefaultClient{
+		Config: &config.Config{
+			ProjectID: "some-project-id-0000-000-000-0000",
+		},
+		HTTPClient: http.DefaultClient,
+	}
+	expectedToken := "expectedToken"
+	expectedClientID := "mock_client_id"
+	expectedClientSecret := "mock_client_id"
+
+	t.Run("sends token request", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/v1/public/some-project-id-0000-000-000-0000/oauth2/introspect", r.URL.Path)
+			assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("content-type"))
+			bytes, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			params, err := url.ParseQuery(string(bytes))
+			require.NoError(t, err)
+
+			assert.Equal(t, expectedClientID, params.Get("client_id"))
+			assert.Equal(t, expectedClientSecret, params.Get("client_secret"))
+			assert.Equal(t, expectedToken, params.Get("token"))
+
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write([]byte(`{
+				"active": true,
+				"aud": ["project-test-0000-000-000-0000"],
+				"client_id": "connected-app-test-0000-000-000-0000",
+				"exp": 1738848103,
+				"iat": 1738844503,
+				"iss": "https://upn.customers.stytch.dev",
+				"scope": "openid email profile",
+				"sub": "member-test-0000-000-000-0000",
+				"token_type": "access_token"
+			}`))
+			assert.NoError(t, err)
+		}))
+
+		client.Config.BaseURI = config.BaseURI(svr.URL)
+
+		res, err := consumer.NewIDPClient(client, nil, nil).
+			IntrospectTokenNetwork(context.Background(), &idp.IntrospectTokenNetworkParams{
+				Token:        expectedToken,
+				ClientID:     expectedClientID,
+				ClientSecret: &expectedClientSecret,
+			})
+		require.NoError(t, err)
+
+		expected := &idp.IntrospectTokenResponse{
+			Active:       true,
+			TokenType:    "access_token",
+			Issuer:       "https://upn.customers.stytch.dev",
+			Subject:      "member-test-0000-000-000-0000",
+			Audience:     []string{"project-test-0000-000-000-0000"},
+			Scope:        "openid email profile",
+			CustomClaims: nil,
+			ClientID:     "connected-app-test-0000-000-000-0000",
+			Expiry:       res.Expiry,
+			IssuedAt:     res.IssuedAt,
+		}
+		assert.Equal(t, expected, res)
+	})
+
+	t.Run("handles inactive token response", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{
+				"active": false
+			}`))
+			assert.NoError(t, err)
+		}))
+
+		client.Config.BaseURI = config.BaseURI(svr.URL)
+
+		_, err := consumer.NewIDPClient(client, nil, nil).
+			IntrospectTokenNetwork(context.Background(), &idp.IntrospectTokenNetworkParams{
+				Token:        expectedToken,
+				ClientID:     expectedClientID,
+				ClientSecret: &expectedClientSecret,
+			})
+		assert.EqualError(t, err, stytcherror.NewInvalidOAuth2TokenError().Error())
+	})
+
+	t.Run("handles error response", func(t *testing.T) {
+		svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, err := w.Write([]byte(`{ "error":"invalid_client" }`))
+			assert.NoError(t, err)
+		}))
+
+		client.Config.BaseURI = config.BaseURI(svr.URL)
+
+		res, err := consumer.NewIDPClient(client, nil, nil).
+			IntrospectTokenNetwork(context.Background(), &idp.IntrospectTokenNetworkParams{
+				Token:        expectedToken,
+				ClientID:     expectedClientID,
+				ClientSecret: &expectedClientSecret,
+			})
+		assert.Nil(t, res)
+		var stytchErr stytcherror.OAuth2Error
+		assert.ErrorAs(t, err, &stytchErr)
+	})
+}
+
+func TestIDP_IntrospectTokenLocal(t *testing.T) {
+	client := &stytch.DefaultClient{
+		Config: &config.Config{
+			ProjectID: "project-test-0000-000-000-0000",
+		},
+		// In these tests, the keyset has already been downloaded, so no other network requests
+		// should be made.
+		HTTPClient: nil,
+	}
+
+	key := rsaKey(t)
+	keyID := "jwk-test-22222222-2222-2222-2222-222222222222"
+	jwks := keyfunc.NewGiven(map[string]keyfunc.GivenKey{
+		keyID: keyfunc.NewGivenRSA(&key.PublicKey, keyfunc.GivenKeyOptions{Algorithm: "RS256"}),
+	})
+
+	policyCache := consumer.NewPolicyCache(consumer.NewRBACClient(client))
+	idpClient := consumer.NewIDPClient(client, jwks, policyCache)
+
+	t.Run("valid JWT", func(t *testing.T) {
+		token := signJWT(t, keyID, key, jwt.MapClaims{
+			"iss":       "https://upn.customers.stytch.dev",
+			"sub":       "member-test-0000-000-000-0000",
+			"aud":       []string{"project-test-0000-000-000-0000"},
+			"iat":       time.Now().Add(-time.Minute).Unix(),
+			"exp":       time.Now().Add(time.Minute).Unix(),
+			"client_id": "connected-app-test-0000-000-000-0000",
+			"scope":     "openid email profile",
+		})
+
+		ctx := context.Background()
+		res, err := idpClient.IntrospectTokenLocal(ctx, &idp.IntrospectTokenLocalParams{
+			Token: token,
+		})
+		require.NoError(t, err)
+
+		expected := &idp.IntrospectTokenResponse{
+			Active:       true,
+			TokenType:    "access_token",
+			Issuer:       "https://upn.customers.stytch.dev",
+			Subject:      "member-test-0000-000-000-0000",
+			Audience:     []string{"project-test-0000-000-000-0000"},
+			Scope:        "openid email profile",
+			CustomClaims: map[string]any{},
+			ClientID:     "connected-app-test-0000-000-000-0000",
+			Expiry:       res.Expiry,
+			IssuedAt:     res.IssuedAt,
+		}
+		assert.Equal(t, expected, res)
+	})
+}


### PR DESCRIPTION
Part of AUTH-5632 and essentially a port of #250 to Consumer

This PR does _not_ handle Consumer `AuthorizationCheck` logic. Will add in a future PR.