### PR TITLE
feat: [AUTH-5632] Refactor internals for Consumer RBAC Authorization

### DIFF
--- a/stytch/b2b/idp.go
+++ b/stytch/b2b/idp.go
@@ -100,7 +100,7 @@ func (c *IDPClient) IntrospectTokenNetwork(
 
 		tokenScopes := strings.Split(strings.TrimSpace(tokenRes.Scope), " ")
 
-		err = shared.PerformScopeAuthorizationCheck(policy, tokenScopes, tokenRes.Organization.OrganizationID, body.AuthorizationCheck)
+		err = shared.PerformB2BScopeAuthorizationCheck(policy, tokenScopes, tokenRes.Organization.OrganizationID, body.AuthorizationCheck)
 		if err != nil {
 			return nil, err
 		}
@@ -175,7 +175,7 @@ func (c *IDPClient) IntrospectTokenLocal(
 
 		tokenScopes := strings.Split(strings.TrimSpace(staticClaims.Scope), " ")
 
-		err = shared.PerformScopeAuthorizationCheck(policy, tokenScopes, staticClaims.Organization.OrganizationID, req.AuthorizationCheck)
+		err = shared.PerformB2BScopeAuthorizationCheck(policy, tokenScopes, staticClaims.Organization.OrganizationID, req.AuthorizationCheck)
 		if err != nil {
 			return nil, err
 		}

--- a/stytch/b2b/sessions.go
+++ b/stytch/b2b/sessions.go
@@ -570,7 +570,7 @@ func (c *SessionsClient) AuthenticateJWTLocal(
 			return nil, fmt.Errorf("failed to get cached policy: %w", err)
 		}
 
-		err = shared.PerformAuthorizationCheck(policy, staticClaims.Session.Roles, memberSession.OrganizationID, authorizationCheck)
+		err = shared.PerformB2BAuthorizationCheck(policy, staticClaims.Session.Roles, memberSession.OrganizationID, authorizationCheck)
 		if err != nil {
 			return nil, err
 		}

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -201,10 +201,10 @@ func (c *SessionsClient) Revoke(
 }
 
 // Migrate a session from an external OIDC compliant endpoint. Stytch will call the external UserInfo
-// endpoint defined in your Stytch Project settings in the [Dashboard](https://stytch.com/docs/dashboard),
-// and then perform a lookup using the `session_token`. If the response contains a valid email address,
-// Stytch will attempt to match that email address with an existing User and create a Stytch Session. You
-// will need to create the user before using this endpoint.
+// endpoint defined in your Stytch Project settings in the [Dashboard](/dashboard), and then perform a
+// lookup using the `session_token`. If the response contains a valid email address, Stytch will attempt to
+// match that email address with an existing User and create a Stytch Session. You will need to create the
+// user before using this endpoint.
 func (c *SessionsClient) Migrate(
 	ctx context.Context,
 	body *sessions.MigrateParams,
@@ -315,8 +315,8 @@ func (c *SessionsClient) GetJWKS(
 
 // Attest: Exchange an auth token issued by a trusted identity provider for a Stytch session. You must
 // first register a Trusted Auth Token profile in the Stytch dashboard
-// [here](https://stytch.com/docs/dashboard/trusted-auth-tokens). If a session token or session JWT is
-// provided, it will add the trusted auth token as an authentication factor to the existing session.
+// [here](/dashboard/trusted-auth-tokens). If a session token or session JWT is provided, it will add the
+// trusted auth token as an authentication factor to the existing session.
 func (c *SessionsClient) Attest(
 	ctx context.Context,
 	body *sessions.AttestParams,

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -22,14 +22,16 @@ import (
 )
 
 type SessionsClient struct {
-	C    stytch.Client
-	JWKS *keyfunc.JWKS
+	C           stytch.Client
+	JWKS        *keyfunc.JWKS
+	PolicyCache *PolicyCache
 }
 
-func NewSessionsClient(c stytch.Client, jwks *keyfunc.JWKS) *SessionsClient {
+func NewSessionsClient(c stytch.Client, jwks *keyfunc.JWKS, policyCache *PolicyCache) *SessionsClient {
 	return &SessionsClient{
-		C:    c,
-		JWKS: jwks,
+		C:           c,
+		JWKS:        jwks,
+		PolicyCache: policyCache,
 	}
 }
 
@@ -201,10 +203,10 @@ func (c *SessionsClient) Revoke(
 }
 
 // Migrate a session from an external OIDC compliant endpoint. Stytch will call the external UserInfo
-// endpoint defined in your Stytch Project settings in the [Dashboard](/dashboard), and then perform a
-// lookup using the `session_token`. If the response contains a valid email address, Stytch will attempt to
-// match that email address with an existing User and create a Stytch Session. You will need to create the
-// user before using this endpoint.
+// endpoint defined in your Stytch Project settings in the [Dashboard](https://stytch.com/docs/dashboard),
+// and then perform a lookup using the `session_token`. If the response contains a valid email address,
+// Stytch will attempt to match that email address with an existing User and create a Stytch Session. You
+// will need to create the user before using this endpoint.
 func (c *SessionsClient) Migrate(
 	ctx context.Context,
 	body *sessions.MigrateParams,
@@ -315,8 +317,8 @@ func (c *SessionsClient) GetJWKS(
 
 // Attest: Exchange an auth token issued by a trusted identity provider for a Stytch session. You must
 // first register a Trusted Auth Token profile in the Stytch dashboard
-// [here](/dashboard/trusted-auth-tokens). If a session token or session JWT is provided, it will add the
-// trusted auth token as an authentication factor to the existing session.
+// [here](https://stytch.com/docs/dashboard/trusted-auth-tokens). If a session token or session JWT is
+// provided, it will add the trusted auth token as an authentication factor to the existing session.
 func (c *SessionsClient) Attest(
 	ctx context.Context,
 	body *sessions.AttestParams,

--- a/stytch/consumer/sessions/types.go
+++ b/stytch/consumer/sessions/types.go
@@ -81,7 +81,8 @@ type AuthenticateParams struct {
 	//
 	//   Custom claims made with reserved claims ("iss", "sub", "aud", "exp", "nbf", "iat", "jti") will be
 	// ignored. Total custom claims size cannot exceed four kilobytes.
-	SessionCustomClaims map[string]any `json:"session_custom_claims,omitempty"`
+	SessionCustomClaims map[string]any      `json:"session_custom_claims,omitempty"`
+	AuthorizationCheck  *AuthorizationCheck `json:"authorization_check,omitempty"`
 }
 
 // AuthenticationFactor:
@@ -164,6 +165,16 @@ type AuthenticationFactor struct {
 type AuthenticatorAppFactor struct {
 	// TOTPID: Globally unique UUID that identifies a TOTP instance.
 	TOTPID string `json:"totp_id,omitempty"`
+}
+
+type AuthorizationCheck struct {
+	ResourceID string `json:"resource_id,omitempty"`
+	Action     string `json:"action,omitempty"`
+}
+
+type AuthorizationVerdict struct {
+	Authorized    bool     `json:"authorized,omitempty"`
+	GrantingRoles []string `json:"granting_roles,omitempty"`
 }
 
 type BiometricFactor struct {
@@ -563,7 +574,8 @@ type AuthenticateResponse struct {
 	// StatusCode: The HTTP status code of the response. Stytch follows standard HTTP response status code
 	// patterns, e.g. 2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX
 	// are server errors.
-	StatusCode int32 `json:"status_code,omitempty"`
+	StatusCode int32                 `json:"status_code,omitempty"`
+	Verdict    *AuthorizationVerdict `json:"verdict,omitempty"`
 }
 
 // ExchangeAccessTokenResponse: Response type for `Sessions.ExchangeAccessToken`.

--- a/stytch/consumer/sessions_test.go
+++ b/stytch/consumer/sessions_test.go
@@ -44,7 +44,8 @@ func TestAuthenticateJWTLocal(t *testing.T) {
 		keyID: keyfunc.NewGivenRSA(&key.PublicKey, keyfunc.GivenKeyOptions{Algorithm: "RS256"}),
 	})
 
-	sessionClient := consumer.NewSessionsClient(client, jwks)
+	policyCache := consumer.NewPolicyCache(consumer.NewRBACClient(client))
+	sessionClient := consumer.NewSessionsClient(client, jwks, policyCache)
 
 	t.Run("expired JWT", func(t *testing.T) {
 		iat := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
@@ -273,7 +274,8 @@ func TestAuthenticateJWTWithClaims(t *testing.T) {
 		keyID: keyfunc.NewGivenRSA(&key.PublicKey, keyfunc.GivenKeyOptions{Algorithm: "RS256"}),
 	})
 
-	sessionClient := consumer.NewSessionsClient(client, jwks)
+	policyCache := consumer.NewPolicyCache(consumer.NewRBACClient(client))
+	sessionClient := consumer.NewSessionsClient(client, jwks, policyCache)
 
 	expectedClaims := map[string]any{
 		"https://my-app.example.net/custom-claim": map[string]any{

--- a/stytch/consumer/stytchapi/stytchapi.go
+++ b/stytch/consumer/stytchapi/stytchapi.go
@@ -168,7 +168,7 @@ func NewClient(projectID string, secret string, opts ...Option) (*API, error) {
 	a.Passwords = consumer.NewPasswordsClient(a.client)
 	a.Project = consumer.NewProjectClient(a.client)
 	a.RBAC = consumer.NewRBACClient(a.client)
-	a.Sessions = consumer.NewSessionsClient(a.client, jwks)
+	a.Sessions = consumer.NewSessionsClient(a.client, jwks, policyCache)
 	a.TOTPs = consumer.NewTOTPsClient(a.client)
 	a.Users = consumer.NewUsersClient(a.client)
 	a.WebAuthn = consumer.NewWebAuthnClient(a.client)

--- a/stytch/shared/rbac_local.go
+++ b/stytch/shared/rbac_local.go
@@ -1,16 +1,18 @@
 package shared
 
 import (
-	"github.com/stytchauth/stytch-go/v16/stytch/b2b/rbac"
-	"github.com/stytchauth/stytch-go/v16/stytch/b2b/sessions"
+	b2brbac "github.com/stytchauth/stytch-go/v16/stytch/b2b/rbac"
+	b2bsessions "github.com/stytchauth/stytch-go/v16/stytch/b2b/sessions"
+	consumerrbac "github.com/stytchauth/stytch-go/v16/stytch/consumer/rbac"
+	consumersessions "github.com/stytchauth/stytch-go/v16/stytch/consumer/sessions"
 	"github.com/stytchauth/stytch-go/v16/stytch/stytcherror"
 )
 
-func PerformAuthorizationCheck(
-	policy *rbac.Policy,
+func PerformB2BAuthorizationCheck(
+	policy *b2brbac.Policy,
 	subjectRoles []string,
 	subjectOrgID string,
-	authorizationCheck *sessions.AuthorizationCheck,
+	authorizationCheck *b2bsessions.AuthorizationCheck,
 ) error {
 	if authorizationCheck == nil {
 		return nil
@@ -20,6 +22,49 @@ func PerformAuthorizationCheck(
 		return stytcherror.NewSessionAuthorizationTenancyError(subjectOrgID, authorizationCheck.OrganizationID)
 	}
 
+	return performRoleAuthorizationCheck(policyFromB2B(policy), authorizationCheckFromB2B(authorizationCheck), subjectRoles)
+}
+
+func PerformB2BScopeAuthorizationCheck(
+	policy *b2brbac.Policy,
+	tokenScopes []string,
+	subjectOrgID string,
+	authorizationCheck *b2bsessions.AuthorizationCheck,
+) error {
+	if authorizationCheck == nil {
+		return nil
+	}
+
+	if subjectOrgID != authorizationCheck.OrganizationID {
+		return stytcherror.NewSessionAuthorizationTenancyError(subjectOrgID, authorizationCheck.OrganizationID)
+	}
+
+	return performScopeAuthorizationCheck(policyFromB2B(policy), authorizationCheckFromB2B(authorizationCheck), tokenScopes)
+}
+
+func PerformConsumerAuthorizationCheck(
+	policy *consumerrbac.Policy,
+	subjectRoles []string,
+	authorizationCheck *consumersessions.AuthorizationCheck,
+) error {
+	if authorizationCheck == nil {
+		return nil
+	}
+	return performRoleAuthorizationCheck(policyFromConsumer(policy), authorizationCheckFromConsumer(authorizationCheck), subjectRoles)
+}
+
+func PerformConsumerScopeAuthorizationCheck(
+	policy *consumerrbac.Policy,
+	tokenScopes []string,
+	authorizationCheck *consumersessions.AuthorizationCheck,
+) error {
+	if authorizationCheck == nil {
+		return nil
+	}
+	return performScopeAuthorizationCheck(policyFromConsumer(policy), authorizationCheckFromConsumer(authorizationCheck), tokenScopes)
+}
+
+func performRoleAuthorizationCheck(policy *policy, authorizationCheck *authorizationCheck, subjectRoles []string) error {
 	for _, role := range policy.Roles {
 		if contains(subjectRoles, role.RoleID) {
 			for _, permission := range role.Permissions {
@@ -32,24 +77,10 @@ func PerformAuthorizationCheck(
 			}
 		}
 	}
-
 	return stytcherror.NewPermissionError()
 }
 
-func PerformScopeAuthorizationCheck(
-	policy *rbac.Policy,
-	tokenScopes []string,
-	subjectOrgID string,
-	authorizationCheck *sessions.AuthorizationCheck,
-) error {
-	if authorizationCheck == nil {
-		return nil
-	}
-
-	if subjectOrgID != authorizationCheck.OrganizationID {
-		return stytcherror.NewSessionAuthorizationTenancyError(subjectOrgID, authorizationCheck.OrganizationID)
-	}
-
+func performScopeAuthorizationCheck(policy *policy, authorizationCheck *authorizationCheck, tokenScopes []string) error {
 	for _, scope := range policy.Scopes {
 		if contains(tokenScopes, scope.Scope) {
 			for _, permission := range scope.Permissions {

--- a/stytch/shared/rbac_local_helpers.go
+++ b/stytch/shared/rbac_local_helpers.go
@@ -1,0 +1,161 @@
+package shared
+
+import (
+	b2brbac "github.com/stytchauth/stytch-go/v16/stytch/b2b/rbac"
+	b2bsessions "github.com/stytchauth/stytch-go/v16/stytch/b2b/sessions"
+	consumerrbac "github.com/stytchauth/stytch-go/v16/stytch/consumer/rbac"
+	consumersessions "github.com/stytchauth/stytch-go/v16/stytch/consumer/sessions"
+)
+
+type policy struct {
+	Roles     []policyRole
+	Resources []policyResource
+	Scopes    []policyScope
+}
+
+type policyRole struct {
+	RoleID      string
+	Description string
+	Permissions []policyRolePermission
+}
+
+type policyRolePermission struct {
+	ResourceID string
+	Actions    []string
+}
+
+type policyScope struct {
+	Scope       string
+	Description string
+	Permissions []policyScopePermission
+}
+
+type policyScopePermission struct {
+	ResourceID string
+	Actions    []string
+}
+
+type policyResource struct {
+	ResourceID  string
+	Description string
+	Actions     []string
+}
+
+func policyFromB2B(p *b2brbac.Policy) *policy {
+	var roles []policyRole
+	for _, role := range p.Roles {
+		var permissions []policyRolePermission
+		for _, permission := range role.Permissions {
+			permissions = append(permissions, policyRolePermission{
+				ResourceID: permission.ResourceID,
+				Actions:    permission.Actions,
+			})
+		}
+
+		roles = append(roles, policyRole{
+			RoleID:      role.RoleID,
+			Description: role.Description,
+			Permissions: permissions,
+		})
+	}
+
+	var resources []policyResource
+	for _, resource := range p.Resources {
+		resources = append(resources, policyResource{
+			ResourceID:  resource.ResourceID,
+			Description: resource.Description,
+			Actions:     resource.Actions,
+		})
+	}
+
+	var scopes []policyScope
+	for _, scope := range p.Scopes {
+		var permissions []policyScopePermission
+		for _, permission := range scope.Permissions {
+			permissions = append(permissions, policyScopePermission{
+				ResourceID: permission.ResourceID,
+				Actions:    permission.Actions,
+			})
+		}
+		scopes = append(scopes, policyScope{
+			Scope:       scope.Scope,
+			Description: scope.Description,
+			Permissions: permissions,
+		})
+	}
+
+	return &policy{
+		Roles:     roles,
+		Resources: resources,
+		Scopes:    scopes,
+	}
+}
+
+func policyFromConsumer(p *consumerrbac.Policy) *policy {
+	var roles []policyRole
+	for _, role := range p.Roles {
+		var permissions []policyRolePermission
+		for _, permission := range role.Permissions {
+			permissions = append(permissions, policyRolePermission{
+				ResourceID: permission.ResourceID,
+				Actions:    permission.Actions,
+			})
+		}
+
+		roles = append(roles, policyRole{
+			RoleID:      role.RoleID,
+			Description: role.Description,
+			Permissions: permissions,
+		})
+	}
+
+	var resources []policyResource
+	for _, resource := range p.Resources {
+		resources = append(resources, policyResource{
+			ResourceID:  resource.ResourceID,
+			Description: resource.Description,
+			Actions:     resource.Actions,
+		})
+	}
+
+	var scopes []policyScope
+	for _, scope := range p.Scopes {
+		var permissions []policyScopePermission
+		for _, permission := range scope.Permissions {
+			permissions = append(permissions, policyScopePermission{
+				ResourceID: permission.ResourceID,
+				Actions:    permission.Actions,
+			})
+		}
+		scopes = append(scopes, policyScope{
+			Scope:       scope.Scope,
+			Description: scope.Description,
+			Permissions: permissions,
+		})
+	}
+
+	return &policy{
+		Roles:     roles,
+		Resources: resources,
+		Scopes:    scopes,
+	}
+}
+
+type authorizationCheck struct {
+	ResourceID string
+	Action     string
+}
+
+func authorizationCheckFromConsumer(c *consumersessions.AuthorizationCheck) *authorizationCheck {
+	return &authorizationCheck{
+		ResourceID: c.ResourceID,
+		Action:     c.Action,
+	}
+}
+
+func authorizationCheckFromB2B(c *b2bsessions.AuthorizationCheck) *authorizationCheck {
+	return &authorizationCheck{
+		ResourceID: c.ResourceID,
+		Action:     c.Action,
+	}
+}

--- a/stytch/shared/rbac_local_helpers.go
+++ b/stytch/shared/rbac_local_helpers.go
@@ -7,6 +7,10 @@ import (
 	consumersessions "github.com/stytchauth/stytch-go/v16/stytch/consumer/sessions"
 )
 
+// This file contains boilerplate stubs to convert B2B and Consumer RBAC policies
+// and authorization check API shapes to the same internal data shape
+// for use in local authorization methods
+
 type policy struct {
 	Roles     []policyRole
 	Resources []policyResource

--- a/stytch/shared/rbac_local_test.go
+++ b/stytch/shared/rbac_local_test.go
@@ -1,6 +1,8 @@
 package shared_test
 
 import (
+	consumerrbac "github.com/stytchauth/stytch-go/v16/stytch/consumer/rbac"
+	consumersessions "github.com/stytchauth/stytch-go/v16/stytch/consumer/sessions"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -146,6 +148,123 @@ func Test_PerformB2BAuthorizationCheck(t *testing.T) {
 				OrganizationID: orgID,
 				ResourceID:     "document",
 				Action:         "delete",
+			},
+		)
+		assert.NoError(t, err)
+	})
+}
+
+func Test_PerformConsumerAuthorizationCheck(t *testing.T) {
+	policy := &consumerrbac.Policy{
+		Roles: []consumerrbac.PolicyRole{
+			{
+				RoleID:      "stytch_member",
+				Description: "member",
+				Permissions: []consumerrbac.PolicyRolePermission{
+					{
+						ResourceID: "document",
+						Actions:    []string{"read", "write"},
+					},
+					{
+						ResourceID: "program",
+						Actions:    []string{"read"},
+					},
+				},
+			},
+			{
+				RoleID:      "stytch_editor",
+				Description: "member",
+				Permissions: []consumerrbac.PolicyRolePermission{
+					{
+						ResourceID: "document",
+						Actions:    []string{"read", "write"},
+					},
+					{
+						ResourceID: "program",
+						Actions:    []string{"read", "execute"},
+					},
+				},
+			},
+			{
+				RoleID:      "stytch_admin",
+				Description: "admin",
+				Permissions: []consumerrbac.PolicyRolePermission{
+					{
+						ResourceID: "document",
+						Actions:    []string{"read", "write", "delete"},
+					},
+					{
+						ResourceID: "program",
+						Actions:    []string{"read", "edit", "execute"},
+					},
+				},
+			},
+		},
+		Resources: []consumerrbac.PolicyResource{
+			{
+				ResourceID:  "document",
+				Description: "All documents",
+				Actions:     []string{"read", "write", "delete"},
+			},
+			{
+				ResourceID:  "program",
+				Description: "An executable program",
+				Actions:     []string{"read", "write", "execute"},
+			},
+		},
+	}
+
+	t.Run("action exists but resource does not", func(t *testing.T) {
+		err := shared.PerformConsumerAuthorizationCheck(
+			policy,
+			[]string{"stytch_member"},
+			&consumersessions.AuthorizationCheck{
+				ResourceID: "resource_that_doesnt_exist",
+				Action:     "read",
+			},
+		)
+		assert.ErrorContains(t, err, stytcherror.NewPermissionError().Error())
+	})
+	t.Run("resource exists but action does not", func(t *testing.T) {
+		err := shared.PerformConsumerAuthorizationCheck(
+			policy,
+			[]string{"stytch_member"},
+			&consumersessions.AuthorizationCheck{
+				ResourceID: "document",
+				Action:     "action_that_doesnt_exist",
+			},
+		)
+		assert.ErrorContains(t, err, stytcherror.NewPermissionError().Error())
+	})
+	t.Run("member has this action but on a different resource", func(t *testing.T) {
+		err := shared.PerformConsumerAuthorizationCheck(
+			policy,
+			[]string{"stytch_member"},
+			&consumersessions.AuthorizationCheck{
+				ResourceID: "program",
+				Action:     "write",
+			},
+		)
+		assert.ErrorContains(t, err, stytcherror.NewPermissionError().Error())
+	})
+	t.Run("another authorization check for a member with more elevated privileges", func(t *testing.T) {
+		err := shared.PerformConsumerAuthorizationCheck(
+			policy,
+			[]string{"stytch_editor"},
+			&consumersessions.AuthorizationCheck{
+				ResourceID: "program",
+				Action:     "edit",
+			},
+		)
+		assert.ErrorContains(t, err, stytcherror.NewPermissionError().Error())
+	})
+	t.Run("no error when the member is authorized", func(t *testing.T) {
+		err := shared.PerformConsumerAuthorizationCheck(
+			policy,
+			[]string{"stytch_admin"},
+			&consumersessions.AuthorizationCheck{
+				ResourceID: "document",
+				Action:     "delete",
 			},
 		)
 		assert.NoError(t, err)

--- a/stytch/shared/rbac_local_test.go
+++ b/stytch/shared/rbac_local_test.go
@@ -1,9 +1,10 @@
 package shared_test
 
 import (
+	"testing"
+
 	consumerrbac "github.com/stytchauth/stytch-go/v16/stytch/consumer/rbac"
 	consumersessions "github.com/stytchauth/stytch-go/v16/stytch/consumer/sessions"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	b2brbac "github.com/stytchauth/stytch-go/v16/stytch/b2b/rbac"


### PR DESCRIPTION
This PR:
- Partially runs codegen to get Consumer Authorization structs 
- Adds internal methods for converting Consumer RBAC and B2B RBAC policies into a shared format
- Refactors the existing B2B RBAC methods to use shared format
- Implements Consumer RBAC internal methods and tests


Next PR:
- Will start to use internal Consumer RBAC methods in Consumer public client endpoints