### PR TITLE
 feat: [AUTH-5632] Expose Consumer RBAC Authorization

### DIFF
--- a/stytch/consumer/idp.go
+++ b/stytch/consumer/idp.go
@@ -90,19 +90,19 @@ func (c *IDPClient) IntrospectTokenNetwork(
 	if !tokenRes.Active {
 		return nil, stytcherror.NewInvalidOAuth2TokenError()
 	}
-	//if body.AuthorizationCheck != nil {
-	//	policy, err := c.PolicyCache.Get(ctx)
-	//	if err != nil {
-	//		return nil, fmt.Errorf("failed to get cached policy: %w", err)
-	//	}
-	//
-	//	tokenScopes := strings.Split(strings.TrimSpace(tokenRes.Scope), " ")
-	//
-	//	err = shared.PerformScopeAuthorizationCheck(policy, tokenScopes, tokenRes.Organization.OrganizationID, body.AuthorizationCheck)
-	//	if err != nil {
-	//		return nil, err
-	//	}
-	//}
+	if body.AuthorizationCheck != nil {
+		policy, err := c.PolicyCache.Get(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cached policy: %w", err)
+		}
+
+		tokenScopes := strings.Split(strings.TrimSpace(tokenRes.Scope), " ")
+
+		err = shared.PerformConsumerScopeAuthorizationCheck(policy, tokenScopes, body.AuthorizationCheck)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	return &tokenRes, nil
 }
@@ -164,20 +164,19 @@ func (c *IDPClient) IntrospectTokenLocal(
 		}
 	}
 
-	//var policy *rbac.Policy
-	//if req.AuthorizationCheck != nil {
-	//	policy, err = c.PolicyCache.Get(ctx)
-	//	if err != nil {
-	//		return nil, fmt.Errorf("failed to get cached policy: %w", err)
-	//	}
-	//
-	//	tokenScopes := strings.Split(strings.TrimSpace(staticClaims.Scope), " ")
-	//
-	//	err = shared.PerformScopeAuthorizationCheck(policy, tokenScopes, staticClaims.Organization.OrganizationID, req.AuthorizationCheck)
-	//	if err != nil {
-	//		return nil, err
-	//	}
-	//}
+	if req.AuthorizationCheck != nil {
+		policy, err := c.PolicyCache.Get(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cached policy: %w", err)
+		}
+
+		tokenScopes := strings.Split(strings.TrimSpace(staticClaims.Scope), " ")
+
+		err = shared.PerformConsumerScopeAuthorizationCheck(policy, tokenScopes, req.AuthorizationCheck)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	return marshalAccessTokenJWTIntoResponse(staticClaims, customClaims)
 }

--- a/stytch/consumer/idp/types.go
+++ b/stytch/consumer/idp/types.go
@@ -1,6 +1,7 @@
 package idp
 
 import (
+	"github.com/stytchauth/stytch-go/v16/stytch/consumer/sessions"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -27,15 +28,15 @@ type IntrospectTokenClaims struct {
 }
 
 type IntrospectTokenLocalParams struct {
-	Token       string
-	MaxTokenAge time.Duration
-	// AuthorizationCheck *sessions.AuthorizationCheck
+	Token              string
+	MaxTokenAge        time.Duration
+	AuthorizationCheck *sessions.AuthorizationCheck
 }
 
 type IntrospectTokenNetworkParams struct {
-	Token         string
-	ClientID      string
-	ClientSecret  *string
-	TokenTypeHint *string
-	// AuthorizationCheck *sessions.AuthorizationCheck
+	Token              string
+	ClientID           string
+	ClientSecret       *string
+	TokenTypeHint      *string
+	AuthorizationCheck *sessions.AuthorizationCheck
 }

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -203,10 +203,10 @@ func (c *SessionsClient) Revoke(
 }
 
 // Migrate a session from an external OIDC compliant endpoint. Stytch will call the external UserInfo
-// endpoint defined in your Stytch Project settings in the [Dashboard](https://stytch.com/docs/dashboard),
-// and then perform a lookup using the `session_token`. If the response contains a valid email address,
-// Stytch will attempt to match that email address with an existing User and create a Stytch Session. You
-// will need to create the user before using this endpoint.
+// endpoint defined in your Stytch Project settings in the [Dashboard](/dashboard), and then perform a
+// lookup using the `session_token`. If the response contains a valid email address, Stytch will attempt to
+// match that email address with an existing User and create a Stytch Session. You will need to create the
+// user before using this endpoint.
 func (c *SessionsClient) Migrate(
 	ctx context.Context,
 	body *sessions.MigrateParams,
@@ -317,8 +317,8 @@ func (c *SessionsClient) GetJWKS(
 
 // Attest: Exchange an auth token issued by a trusted identity provider for a Stytch session. You must
 // first register a Trusted Auth Token profile in the Stytch dashboard
-// [here](https://stytch.com/docs/dashboard/trusted-auth-tokens). If a session token or session JWT is
-// provided, it will add the trusted auth token as an authentication factor to the existing session.
+// [here](/dashboard/trusted-auth-tokens). If a session token or session JWT is provided, it will add the
+// trusted auth token as an authentication factor to the existing session.
 func (c *SessionsClient) Attest(
 	ctx context.Context,
 	body *sessions.AttestParams,
@@ -366,7 +366,8 @@ func (c *SessionsClient) AuthenticateJWT(
 		return c.Authenticate(ctx, body)
 	}
 
-	session, err := c.AuthenticateJWTLocal(body.SessionJWT, maxTokenAge)
+	session, err := c.AuthenticateJWTLocal(body.SessionJWT, maxTokenAge,
+		WithContext(ctx), WithAuthorizationCheck(body.AuthorizationCheck))
 	if err != nil {
 		// JWT couldn't be verified locally. Check with the Stytch API.
 		return c.Authenticate(ctx, body)
@@ -421,9 +422,29 @@ func (c *SessionsClient) AuthenticateJWTWithClaims(
 	return resp, nil
 }
 
+// TODO (vNext): Replace this with a (ctx, Params) shape instead of these backwards compatible options
+type authenticateJWTLocalState struct {
+	ctx       context.Context
+	authCheck *sessions.AuthorizationCheck
+}
+type authenticateJWTLocalOpt func(*authenticateJWTLocalState)
+
+func WithContext(ctx context.Context) authenticateJWTLocalOpt {
+	return func(s *authenticateJWTLocalState) {
+		s.ctx = ctx
+	}
+}
+
+func WithAuthorizationCheck(authCheck *sessions.AuthorizationCheck) authenticateJWTLocalOpt {
+	return func(s *authenticateJWTLocalState) {
+		s.authCheck = authCheck
+	}
+}
+
 func (c *SessionsClient) AuthenticateJWTLocal(
 	token string,
 	maxTokenAge time.Duration,
+	opts ...authenticateJWTLocalOpt,
 ) (*sessions.Session, error) {
 	if c.JWKS == nil {
 		return nil, stytcherror.ErrJWKSNotInitialized
@@ -469,6 +490,26 @@ func (c *SessionsClient) AuthenticateJWTLocal(
 	for key := range customClaims {
 		if shared.ReservedClaim(key) {
 			delete(customClaims, key)
+		}
+	}
+
+	// For backwards API compatibility, we accept ctx and authorizationCheck as options
+	authorizeOpts := &authenticateJWTLocalState{
+		ctx: context.Background(),
+	}
+	for _, opt := range opts {
+		opt(authorizeOpts)
+	}
+
+	if authorizeOpts.authCheck != nil {
+		policy, err := c.PolicyCache.Get(authorizeOpts.ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cached policy: %w", err)
+		}
+
+		err = shared.PerformConsumerAuthorizationCheck(policy, staticClaims.StytchSession.Roles, authorizeOpts.authCheck)
+		if err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Final PR in the chain - this exposes the RBAC methods for consumption in Consumer and adds additional tests for scope validation. 

Some futzing around with `AuthenticateJWTLocal` was required to avoid doing a breaking change - it only takes in positional arguments today so we needed to add an `...opts` pattern to permit callers to pass in new fields. We'll fix it in the next major release- there are a bunch of ways we want the `AuthenticateJWTLocal` API to change (like claim unmarshaling!) 