### PR TITLE
Saturate roles on consumer session object

### DIFF
--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "16.39.0"
+const APIVersion = "16.39.1"

--- a/stytch/consumer/sessions.go
+++ b/stytch/consumer/sessions.go
@@ -551,6 +551,7 @@ func marshalJWTIntoSession(claims sessions.Claims, customClaims map[string]any) 
 		Attributes:            &claims.StytchSession.Attributes,
 		AuthenticationFactors: claims.StytchSession.AuthenticationFactors,
 		CustomClaims:          customClaims,
+		Roles:                 claims.StytchSession.Roles,
 	}, nil
 }
 


### PR DESCRIPTION
Saturates the consumer session object from authenticatejwtlocal with the session roles for consumers.