### PR TITLE
[STYTCH-2][AUTH-5999] Local authorization manual methods for custom org roles.

### DIFF
--- a/stytch/b2b/sessions.go
+++ b/stytch/b2b/sessions.go
@@ -571,7 +571,18 @@ func (c *SessionsClient) AuthenticateJWTLocal(
 			return nil, fmt.Errorf("failed to get cached policy: %w", err)
 		}
 
-		err = shared.PerformB2BAuthorizationCheck(policy, staticClaims.Session.Roles, memberSession.OrganizationID, authorizationCheck)
+		orgPolicy, err := c.PolicyCache.GetOrgPolicy(ctx, memberSession.OrganizationID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get cached org policy: %w", err)
+		}
+
+		err = shared.PerformB2BAuthorizationCheck(shared.PerformB2BAuthorizationCheckIn{
+			ProjectPolicy:      policy,
+			OrgPolicy:          orgPolicy,
+			SubjectRoles:       staticClaims.Session.Roles,
+			SubjectOrgID:       memberSession.OrganizationID,
+			AuthorizationCheck: authorizationCheck,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/stytch/config/version.go
+++ b/stytch/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-const APIVersion = "17.1.0"
+const APIVersion = "17.2.0"

--- a/stytch/shared/rbac_local_helpers.go
+++ b/stytch/shared/rbac_local_helpers.go
@@ -45,9 +45,9 @@ type policyResource struct {
 	Actions     []string
 }
 
-func policyFromB2B(p *b2brbac.Policy) *policy {
+func policyFromB2B(projectPolicy *b2brbac.Policy, orgPolicy *b2brbac.OrgPolicy) *policy {
 	var roles []policyRole
-	for _, role := range p.Roles {
+	for _, role := range projectPolicy.Roles {
 		var permissions []policyRolePermission
 		for _, permission := range role.Permissions {
 			permissions = append(permissions, policyRolePermission{
@@ -55,16 +55,31 @@ func policyFromB2B(p *b2brbac.Policy) *policy {
 				Actions:    permission.Actions,
 			})
 		}
-
 		roles = append(roles, policyRole{
 			RoleID:      role.RoleID,
 			Description: role.Description,
 			Permissions: permissions,
 		})
 	}
+	if orgPolicy != nil {
+		for _, role := range orgPolicy.Roles {
+			var permissions []policyRolePermission
+			for _, permission := range role.Permissions {
+				permissions = append(permissions, policyRolePermission{
+					ResourceID: permission.ResourceID,
+					Actions:    permission.Actions,
+				})
+			}
+			roles = append(roles, policyRole{
+				RoleID:      role.RoleID,
+				Description: role.Description,
+				Permissions: permissions,
+			})
+		}
+	}
 
 	var resources []policyResource
-	for _, resource := range p.Resources {
+	for _, resource := range projectPolicy.Resources {
 		resources = append(resources, policyResource{
 			ResourceID:  resource.ResourceID,
 			Description: resource.Description,
@@ -73,7 +88,7 @@ func policyFromB2B(p *b2brbac.Policy) *policy {
 	}
 
 	var scopes []policyScope
-	for _, scope := range p.Scopes {
+	for _, scope := range projectPolicy.Scopes {
 		var permissions []policyScopePermission
 		for _, permission := range scope.Permissions {
 			permissions = append(permissions, policyScopePermission{


### PR DESCRIPTION
## Description

- Adds local authorization methods for handling Custom Org Roles.
- Part of AUTH-5999, STYTCH-2.