### PR TITLE
chore: migrate GitHub runners to ubuntu-latest-public

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     name: Publish GitHub release
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
 
     steps:
       - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
           args: --timeout 5m
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
 
     strategy:
       fail-fast: false

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     name: Check links in README.md
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Migrates all `ubuntu-latest` runner references to `ubuntu-latest-public` (org-scoped GitHub-hosted runner group).